### PR TITLE
詳細ボタン、詳細ボタンの別画面、画像（挿入、削除）関連の実装。

### DIFF
--- a/Inventory Management App/CommonDatabaseOperations.cs
+++ b/Inventory Management App/CommonDatabaseOperations.cs
@@ -119,13 +119,13 @@ namespace Inventory_Management_App
                 {
                     connection.Open(); // 接続を開く
 
-                    // 外部キー制約を有効化（セッションレベル）→必須(ONにしないとON DELETE CASCADEが動かない(整合性が失われる）)
-                    //using (var enableFK = connection.CreateCommand())
-                    //{
-                    //    enableFK.CommandText = "PRAGMA foreign_keys = ON"; // 外部キー制約を有効化
-                    //    enableFK.ExecuteNonQuery(); // コマンドを実行
-                    //}
-                    
+                    //外部キー制約を有効化（セッションレベル）→必須(ONにしないとON DELETE CASCADEが動かない(整合性が失われる）)
+                    using (var enableFK = connection.CreateCommand())
+                    {
+                        enableFK.CommandText = "PRAGMA foreign_keys = ON"; // 外部キー制約を有効化
+                        enableFK.ExecuteNonQuery(); // コマンドを実行
+                    }
+
                     using (var transaction = connection.BeginTransaction())
                     {
                         try
@@ -188,6 +188,13 @@ namespace Inventory_Management_App
                 {
                     connection.Open();
 
+                    // 外部キー制約を有効化
+                    using (var enableFK = connection.CreateCommand())
+                    {
+                        enableFK.CommandText = "PRAGMA foreign_keys = ON";
+                        enableFK.ExecuteNonQuery();
+                    }
+
                     // SQLコマンドを作成して実行
                     using (var command = connection.CreateCommand())
                     {
@@ -227,6 +234,14 @@ namespace Inventory_Management_App
                 using (var connection = new SqliteConnection(connectionString))
                 {
                     connection.Open();
+
+                    //外部キー制約を有効化
+                    using (var enableFK = connection.CreateCommand())
+                    {
+                        enableFK.CommandText = "PRAGMA foreign_keys = ON"; // 外部キー制約を有効化
+                        enableFK.ExecuteNonQuery(); // コマンドを実行
+                    }
+
                     using (var command = connection.CreateCommand())
                     {
                         command.CommandText = query; // SQLクエリを設定
@@ -263,10 +278,12 @@ namespace Inventory_Management_App
             int ColumnIndexQuantity,
             int ColumnIndexComment,
             out int InsertedCount,
-            out int UpdatedCount)
+            out int UpdatedCount,
+            out List<int> NewInsertedIds) // 新規挿入されたIDリストを出力
         {
             int Inserted = 0; // 挿入件数カウンタ
             int Updated = 0;  // 更新件数カウンタ
+            List<int> InsertedIds = new List<int>(); // 新規挿入されたIDリスト
 
             // トランザクション内で保存処理を実行
             bool TransactionSucceeded = ExecuteWithTransaction(
@@ -332,6 +349,19 @@ namespace Inventory_Management_App
                                 ic.Parameters.AddWithValue("@Comment", Comment);
                                 ic.ExecuteNonQuery();
                             }
+
+                            // 新規挿入されたIDを取得
+                            using (var getIdCommand = connection.CreateCommand())
+                            {
+                                getIdCommand.Transaction = transaction;
+                                getIdCommand.CommandText = "SELECT last_insert_rowid();";
+                                object lastId = getIdCommand.ExecuteScalar();
+                                if (lastId != null && long.TryParse(lastId.ToString(), out long insertedId))
+                                {
+                                    InsertedIds.Add((int)insertedId); // IDをリストに追加
+                                }
+                            }
+
                             Inserted++;
                         }
                     }
@@ -341,6 +371,7 @@ namespace Inventory_Management_App
 
             InsertedCount = Inserted; // 挿入件数を出力パラメータに設定
             UpdatedCount = Updated; // 更新件数を出力パラメータに設定
+            NewInsertedIds = InsertedIds; // 新規挿入されたIDリストを出力パラメータに設定
             return TransactionSucceeded; // 全体の成功状態を返す
         }
 

--- a/Inventory Management App/CommonDatabaseOperations.cs
+++ b/Inventory Management App/CommonDatabaseOperations.cs
@@ -1,0 +1,513 @@
+﻿using Microsoft.Data.Sqlite;
+using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Drawing;
+using System.IO;
+using System.Windows.Forms;
+
+namespace Inventory_Management_App
+{
+    // データベース操作の共通処理を行うクラス
+    
+    public static class DatabaseHelper
+    {
+        private static string dbPath; // データベースファイルのパス
+        private static string connectionString; // 接続文字列
+
+
+        // データベースパスを取得
+        public static string DbPath
+        {
+            get
+            {
+                // 一度設定されたら保持
+                if (string.IsNullOrEmpty(dbPath))
+                {
+                    // 初回はアプリケーションの実行フォルダに作る（権限問題を避けるため）
+                    dbPath = Path.Combine(Application.StartupPath, "InventoryData.db");
+                }
+                return dbPath; // データベースファイルのパス
+            }
+        }
+
+        // 接続文字列を取得
+        public static string ConnectionString
+        {
+            get
+            {
+                // 一度設定されたら保持
+                if (string.IsNullOrEmpty(connectionString))
+                {
+                    connectionString = $"Data Source={DbPath};"; // SQLiteの接続文字列
+                }
+                return connectionString; // 接続文字列
+            }
+        }
+
+        /// データベースの初期化（ファイル作成とテーブル作成）
+        public static void InitializeDatabase()
+        {
+            // データベースファイルが存在しない場合は作成
+            if (!File.Exists(DbPath))
+            {
+                using (File.Create(DbPath)) { } // 空のファイルを作成
+            }
+
+            // テーブル作成はトランザクションで実施
+            ExecuteWithTransaction(
+                ConnectionString,
+                (connection, transaction) =>
+                {
+                    // 外部キー制約を有効化（トランザクションに関連付ける）
+                    using (var cmd = connection.CreateCommand())
+                    {
+                        cmd.CommandText = "PRAGMA foreign_keys = ON";
+                        cmd.Transaction = transaction;
+                        cmd.ExecuteNonQuery();
+                    }
+
+                    // InventoryItemsテーブル作成
+                    string createInventoryTableQuery = @"
+                        CREATE TABLE IF NOT EXISTS InventoryItems ( 
+                            Id INTEGER PRIMARY KEY AUTOINCREMENT, 
+                            IsChecked INTEGER NOT NULL DEFAULT 0, 
+                            Time TEXT NOT NULL,
+                            Quantity INTEGER NOT NULL DEFAULT 0,
+                            Comment TEXT
+                        )";
+
+                    // InventoryItemsテーブル作成
+                    using (var command = connection.CreateCommand())
+                    {
+                        command.Transaction = transaction; 
+                        command.CommandText = createInventoryTableQuery; 
+                        command.ExecuteNonQuery();
+                    }
+
+                    // Imagesテーブル作成(InventoryItemId外部キー付き)
+                    string createImagesTableQuery = @"
+                        CREATE TABLE IF NOT EXISTS Images (
+                            Id INTEGER PRIMARY KEY AUTOINCREMENT,
+                            InventoryItemId INTEGER,
+                            ImageData BLOB NOT NULL,
+                            CreatedAt TEXT NOT NULL,
+                            FOREIGN KEY (InventoryItemId) REFERENCES InventoryItems(Id) ON DELETE CASCADE
+                        )";
+
+                    // Imagesテーブル作成
+                    using (var command = connection.CreateCommand())
+                    {
+                        command.Transaction = transaction;
+                        command.CommandText = createImagesTableQuery;
+                        command.ExecuteNonQuery();
+                    }
+                },
+                null  // 初期化時はメッセージ表示なし
+            );
+        }
+
+        /// トランザクション内でデータベース操作を実行する共通メソッド
+        
+        public static bool ExecuteWithTransaction(
+            string connectionString,
+            Action<SqliteConnection, SqliteTransaction> action,
+            string successMessage = null)
+        {
+            try
+            {
+                // データベース接続を開く
+                using (var connection = new SqliteConnection(connectionString))
+                {
+                    connection.Open(); // 接続を開く
+
+                    // 外部キー制約を有効化（セッションレベル）
+                    using (var enableFK = connection.CreateCommand())
+                    {
+                        enableFK.CommandText = "PRAGMA foreign_keys = ON"; // 外部キー制約を有効化
+                        enableFK.ExecuteNonQuery();
+                    }
+
+                    using (var transaction = connection.BeginTransaction())
+                    {
+                        try
+                        {
+                            // 渡された処理を実行
+                            action(connection, transaction);
+
+                            // トランザクションコミット
+                            transaction.Commit();
+
+                            // 成功メッセージの表示（指定されている場合）
+                            if (!string.IsNullOrEmpty(successMessage))
+                            {
+                                MessageBox.Show(
+                                    successMessage,
+                                    "成功",
+                                    MessageBoxButtons.OK,
+                                    MessageBoxIcon.Information);
+                            }
+
+                            return true;
+                        }
+                        catch (Exception)
+                        {
+                            // エラー時はロールバック
+                            try
+                            {
+                                transaction.Rollback();
+                            }
+                            catch { /* rollback失敗は無視 */ }
+                            throw;
+                        }
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                MessageBox.Show(
+                    $"データベース操作に失敗しました: {ex.Message}",
+                    "エラー",
+                    MessageBoxButtons.OK,
+                    MessageBoxIcon.Error);
+                return false;
+            }
+        }
+
+        // SQLコマンドを実行してデータを取得する共通メソッド（SELECT用）
+        
+        public static bool ExecuteReader(
+            string connectionString, // 接続文字列
+            string query, // SQLクエリ
+            Action<SqliteDataReader> readerAction) // データリーダー処理
+        {
+            try
+            {
+                // データベース接続を開く
+                using (var connection = new SqliteConnection(connectionString))
+                {
+                    connection.Open();
+
+                    // SQLコマンドを作成して実行
+                    using (var command = connection.CreateCommand())
+                    {
+                        command.CommandText = query; // SQLクエリを設定
+
+                        // データリーダーを取得
+                        using (var reader = command.ExecuteReader())
+                        {
+                            readerAction(reader); // データリーダー処理を実行
+                        }
+                    }
+                }
+                return true; // 成功
+            }
+            catch (Exception ex)
+            {
+                MessageBox.Show(
+                    $"データの取得に失敗しました: {ex.Message}",
+                    "エラー",
+                    MessageBoxButtons.OK,
+                    MessageBoxIcon.Error);
+                return false;
+            }
+        }
+
+        // パラメータ付きSQLコマンドを実行してデータを取得する共通メソッド（SELECT用）
+        
+        public static bool ExecuteReaderWithParameters(
+            string connectionString, // 接続文字列
+            string query, // SQLクエリ
+            Action<SqliteCommand> parameterSetter, // パラメータ設定アクション
+            Action<SqliteDataReader> readerAction) // データリーダー処理アクション
+        {
+            try
+            {
+                //  データベース接続を開く
+                using (var connection = new SqliteConnection(connectionString))
+                {
+                    connection.Open();
+                    // SQLコマンドを作成して実行
+                    using (var command = connection.CreateCommand())
+                    {
+                        command.CommandText = query; // SQLクエリを設定
+                        // parameterSetter は SqliteCommand を期待
+                        parameterSetter?.Invoke((SqliteCommand)command); // パラメータを設定
+                        using (var reader = command.ExecuteReader()) // データリーダーを取得
+                        {
+                            readerAction(reader); // データリーダー処理を実行
+                        }
+                    }
+                }
+                return true; // 成功
+            }
+            catch (Exception ex)
+            {
+                MessageBox.Show(
+                    $"データの取得に失敗しました: {ex.Message}",
+                    "エラー",
+                    MessageBoxButtons.OK,
+                    MessageBoxIcon.Error);
+                return false;
+            }
+        }
+
+        // 単一のSQLコマンドを実行する（INSERT/UPDATE/DELETE用）
+        
+        public static bool ExecuteNonQuery(
+            string connectionString,
+            string query,
+            Action<SqliteCommand> parameters = null, // パラメータ設定アクション
+            string successMessage = null) // 成功メッセージ
+        {
+            // トランザクション内で実行
+            return ExecuteWithTransaction(
+                connectionString,
+                (connection, transaction) =>
+                {
+                    // SQLコマンドを作成して実行
+                    using (var command = connection.CreateCommand())
+                    {
+                        command.Transaction = transaction; // トランザクションを関連付け
+                        command.CommandText = query; // SQLクエリを設定
+                        parameters?.Invoke((SqliteCommand)command); // パラメータを設定
+                        command.ExecuteNonQuery(); // コマンドを実行
+                    }
+                },
+                successMessage // 成功メッセージ
+            );
+        }
+
+        // InventoryItemsテーブルの全データを保存する
+        
+        public static bool SaveInventoryItems(
+            DataGridView dataGridView,
+            int ColumnIndexCheckbox,
+            int ColumnIndexTime,
+            int ColumnIndexQuantity,
+            int ColumnIndexComment,
+            out int InsertedCount,
+            out int UpdatedCount)
+        {
+            int Inserted = 0;
+            int Updated = 0;
+
+            bool Success = ExecuteWithTransaction(
+                ConnectionString,
+                (connection, transaction) =>
+                {
+                    string UpdateQuery = @"
+                        UPDATE InventoryItems
+                        SET IsChecked = @IsChecked,
+                            Time = @Time,
+                            Quantity = @Quantity,
+                            Comment = @Comment
+                        WHERE Id = @Id";
+
+                    string InsertQuery = @"
+                        INSERT INTO InventoryItems (IsChecked, Time, Quantity, Comment)
+                        VALUES (@IsChecked, @Time, @Quantity, @Comment)";
+
+                    foreach (DataGridViewRow row in dataGridView.Rows)
+                    {
+                        // 各セルの値を取得（安全に） ?の書き方
+                        bool IsChecked = row.Cells[ColumnIndexCheckbox].Value is bool checkValue && checkValue;
+                        
+                        string Time = row.Cells[ColumnIndexTime].Value?.ToString()
+                                     ?? DateTime.Now.ToString("HH:mm:ss");
+
+                        string QuantityText = row.Cells[ColumnIndexQuantity].Value?.ToString()?.Replace(",", "")
+                                            ?? "0";
+
+                        int Quantity = int.TryParse(QuantityText, out int qty) ? qty : 0;
+
+                        string Comment = row.Cells[ColumnIndexComment].Value?.ToString() ?? "";
+
+                        // 既存データの更新 or 新規挿入
+                        if (row.Tag != null && row.Tag is int id)
+                        {
+                            // 更新処理
+                            using (var UpdateCommand = connection.CreateCommand())
+                            {
+                                UpdateCommand.Transaction = transaction;
+                                UpdateCommand.CommandText = UpdateQuery;
+                                var uc = (SqliteCommand)UpdateCommand;
+                                uc.Parameters.AddWithValue("@Id", id);
+                                uc.Parameters.AddWithValue("@IsChecked", IsChecked ? 1 : 0);
+                                uc.Parameters.AddWithValue("@Time", Time);
+                                uc.Parameters.AddWithValue("@Quantity", Quantity);
+                                uc.Parameters.AddWithValue("@Comment", Comment);
+                                uc.ExecuteNonQuery();
+                            }
+                            Updated++;
+                        }
+                        else
+                        {
+                            // 挿入処理
+                            using (var InsertCommand = connection.CreateCommand())
+                            {
+                                InsertCommand.Transaction = transaction;
+                                InsertCommand.CommandText = InsertQuery;
+                                var ic = (SqliteCommand)InsertCommand;
+                                ic.Parameters.AddWithValue("@IsChecked", IsChecked ? 1 : 0);
+                                ic.Parameters.AddWithValue("@Time", Time);
+                                ic.Parameters.AddWithValue("@Quantity", Quantity);
+                                ic.Parameters.AddWithValue("@Comment", Comment);
+                                ic.ExecuteNonQuery();
+                            }
+                            Inserted++;
+                        }
+                    }
+                },
+                null  // 成功メッセージは呼び出し側で表示
+            );
+
+            InsertedCount = Inserted; // 挿入件数を出力パラメータに設定
+            UpdatedCount = Updated; // 更新件数を出力パラメータに設定
+            return Success; // 全体の成功状態を返す
+        }
+
+        // 画像データをデータベースに保存する
+        
+        public static bool SaveImage(byte[] imageData, int? inventoryItemId = null)
+        {
+            return ExecuteWithTransaction(
+                ConnectionString,
+                (connection, transaction) =>
+                {
+                    string InsertQuery = @"
+                        INSERT INTO Images (InventoryItemId, ImageData, CreatedAt) 
+                        VALUES (@InventoryItemId, @ImageData, @CreatedAt)";
+
+                    using (var command = connection.CreateCommand())
+                    {
+                        command.Transaction = transaction;
+                        command.CommandText = InsertQuery;
+                        var cmd = (SqliteCommand)command;
+                        cmd.Parameters.AddWithValue("@InventoryItemId",
+                            inventoryItemId.HasValue ? (object)inventoryItemId.Value : DBNull.Value);
+                        cmd.Parameters.AddWithValue("@ImageData", imageData);
+                        cmd.Parameters.AddWithValue("@CreatedAt", DateTime.Now.ToString("yyyy-MM-dd HH:mm:ss"));
+                        cmd.ExecuteNonQuery();
+                    }
+                },
+                "画像をデータベースに保存しました。"
+            );
+        }
+
+        // 指定されたInventoryItemIdに関連する画像を取得
+        
+        public static List<Image> LoadImagesForInventoryItem(int inventoryItemId)
+        {
+            // 画像リストを初期化
+            List<Image> images = new List<Image>();
+
+            // データベースから画像データを取得
+            ExecuteReaderWithParameters(
+                ConnectionString,
+                "SELECT ImageData FROM Images WHERE InventoryItemId = @InventoryItemId ORDER BY CreatedAt DESC", // SQLクエリ
+                (command) =>
+                {
+                    // パラメータを設定
+                    command.Parameters.AddWithValue("@InventoryItemId", inventoryItemId);
+                },
+                (reader) => // データリーダー処理
+                {
+                    // 画像データを読み込み
+                    while (reader.Read())
+                    {
+                        // BLOBデータを取得
+                        byte[] imageData = (byte[])reader["ImageData"];
+                        // バイト配列からImageオブジェクトを作成
+                        using (var ms = new MemoryStream(imageData))
+                        {
+                            Image img = Image.FromStream(ms); // 元のImageオブジェクト
+                            Image clonedImage = new Bitmap(img); // クローンを作成
+                            images.Add(clonedImage); // クローンをリストに追加
+                        }
+                    }
+                }
+            );
+
+            return images; // 画像リストを返す
+        }
+
+        // DataGridViewからデータを読み込む
+        
+        public static void LoadInventoryDataToGridView(DataGridView gridView)
+        {
+            // 既存の行をクリア
+            gridView.Rows.Clear();
+
+            // データベースからInventoryItemsデータを取得してDataGridViewに追加
+            ExecuteReader(
+                ConnectionString,
+                "SELECT * FROM InventoryItems ORDER BY Id",
+                (reader) =>
+                {
+                    while (reader.Read())
+                    {
+                        int Id = reader.GetInt32(0);
+                        bool IsChecked = reader.GetInt32(1) == 1;
+                        string Time = reader.GetString(2);
+                        int Quantity = reader.GetInt32(3);
+                        string Comment = reader.IsDBNull(4) ? "" : reader.GetString(4);
+
+                        // DataGridViewに行を追加（Delete/Detail列分もプレースホルダを入れる）
+                        int rowIndex = gridView.Rows.Add(
+                            IsChecked,
+                            Time,
+                            Quantity.ToString("N0"),
+                            Comment,
+                            "", // Delete ボタンセルは UseColumnTextForButtonValue=true なので値は不要
+                            ""  // Detail ボタンセル
+                        );
+
+                        // 行のTagにIDを保存
+                        gridView.Rows[rowIndex].Tag = Id;
+                    }
+                }
+            );
+        }
+
+        // すべてのInventoryItemsデータを削除する
+        
+        public static bool ClearAllInventoryItems()
+        {
+            // トランザクション内で削除処理を実行
+            return ExecuteWithTransaction(
+                ConnectionString,
+                (connection, transaction) =>
+                {
+                    // InventoryItemIdがNULLの画像を先に削除
+                    using (var command = connection.CreateCommand())
+                    {
+                        command.Transaction = transaction;
+                        command.CommandText = "DELETE FROM Images WHERE InventoryItemId IS NULL"; // NULLの画像を削除
+                        command.ExecuteNonQuery();
+                    }
+                    // 全データを削除（ON DELETE CASCADEにより関連画像も自動削除）
+                    using (var command = connection.CreateCommand())
+                    {
+                        command.Transaction = transaction;
+                        command.CommandText = "DELETE FROM InventoryItems"; // すべてのInventoryItemsを削除
+                        command.ExecuteNonQuery();
+                    }
+                },
+                "すべてのデータをクリアしました。"
+            );
+        }
+
+        // 指定されたIDのInventoryItemを削除
+        
+        public static bool DeleteInventoryItem(int id)
+        {
+            return ExecuteNonQuery(
+                ConnectionString,
+                "DELETE FROM InventoryItems WHERE Id = @Id",
+                (command) => command.Parameters.AddWithValue("@Id", id),
+                null
+            );
+        }
+    }
+}

--- a/Inventory Management App/CommonDatabaseOperations.cs
+++ b/Inventory Management App/CommonDatabaseOperations.cs
@@ -59,36 +59,31 @@ namespace Inventory_Management_App
                 ConnectionString,
                 (connection, transaction) =>
                 {
-                    // 外部キー制約を有効化（トランザクションに関連付ける）
-                    using (var cmd = connection.CreateCommand())
-                    {
-                        cmd.CommandText = "PRAGMA foreign_keys = ON";
-                        cmd.Transaction = transaction;
-                        cmd.ExecuteNonQuery();
-                    }
 
-                    // InventoryItemsテーブル作成
+                    // InventoryItemsテーブル作成(在庫項目)
                     string createInventoryTableQuery = @"
                         CREATE TABLE IF NOT EXISTS InventoryItems ( 
-                            Id INTEGER PRIMARY KEY AUTOINCREMENT, 
+                            Id INTEGER PRIMARY KEY AUTOINCREMENT,
                             IsChecked INTEGER NOT NULL DEFAULT 0, 
                             Time TEXT NOT NULL,
-                            Quantity INTEGER NOT NULL DEFAULT 0,
-                            Comment TEXT
+                            Quantity INTEGER NOT NULL DEFAULT 0, 
+                            Comment TEXT 
                         )";
 
                     // InventoryItemsテーブル作成
                     using (var command = connection.CreateCommand())
                     {
-                        command.Transaction = transaction; 
-                        command.CommandText = createInventoryTableQuery; 
-                        command.ExecuteNonQuery();
+                        command.Transaction = transaction; // トランザクションを関連付け 
+                        command.CommandText = createInventoryTableQuery;  // SQLコマンドを設定
+                        command.ExecuteNonQuery(); // コマンドを実行
                     }
 
-                    // Imagesテーブル作成(InventoryItemId外部キー付き)
+
+
+                    // Imagesテーブル作成(画像項目,InventoryItemId外部キー付き、ON DELETE CASCADEを定義)
                     string createImagesTableQuery = @"
                         CREATE TABLE IF NOT EXISTS Images (
-                            Id INTEGER PRIMARY KEY AUTOINCREMENT,
+                            Id INTEGER PRIMARY KEY AUTOINCREMENT, 
                             InventoryItemId INTEGER,
                             ImageData BLOB NOT NULL,
                             CreatedAt TEXT NOT NULL,
@@ -102,6 +97,9 @@ namespace Inventory_Management_App
                         command.CommandText = createImagesTableQuery;
                         command.ExecuteNonQuery();
                     }
+
+                    
+
                 },
                 null  // 初期化時はメッセージ表示なし
             );
@@ -111,7 +109,7 @@ namespace Inventory_Management_App
         
         public static bool ExecuteWithTransaction(
             string connectionString,
-            Action<SqliteConnection, SqliteTransaction> action,
+            Action<SqliteConnection, SqliteTransaction> action, // 実行する処理
             string successMessage = null)
         {
             try
@@ -121,13 +119,13 @@ namespace Inventory_Management_App
                 {
                     connection.Open(); // 接続を開く
 
-                    // 外部キー制約を有効化（セッションレベル）
-                    using (var enableFK = connection.CreateCommand())
-                    {
-                        enableFK.CommandText = "PRAGMA foreign_keys = ON"; // 外部キー制約を有効化
-                        enableFK.ExecuteNonQuery();
-                    }
-
+                    // 外部キー制約を有効化（セッションレベル）→必須(ONにしないとON DELETE CASCADEが動かない(整合性が失われる）)
+                    //using (var enableFK = connection.CreateCommand())
+                    //{
+                    //    enableFK.CommandText = "PRAGMA foreign_keys = ON"; // 外部キー制約を有効化
+                    //    enableFK.ExecuteNonQuery(); // コマンドを実行
+                    //}
+                    
                     using (var transaction = connection.BeginTransaction())
                     {
                         try
@@ -179,7 +177,9 @@ namespace Inventory_Management_App
         public static bool ExecuteReader(
             string connectionString, // 接続文字列
             string query, // SQLクエリ
-            Action<SqliteDataReader> readerAction) // データリーダー処理
+            Action<SqliteDataReader> readerAction, // データリーダー処理アクション
+            Action<SqliteCommand> parameterSetter = null // パラメータ設定アクション（省略可）
+            ) 
         {
             try
             {
@@ -192,6 +192,7 @@ namespace Inventory_Management_App
                     using (var command = connection.CreateCommand())
                     {
                         command.CommandText = query; // SQLクエリを設定
+                        parameterSetter?.Invoke((SqliteCommand)command); // パラメータを設定（必要な場合）
 
                         // データリーダーを取得
                         using (var reader = command.ExecuteReader())
@@ -209,73 +210,48 @@ namespace Inventory_Management_App
                     "エラー",
                     MessageBoxButtons.OK,
                     MessageBoxIcon.Error);
-                return false;
-            }
-        }
-
-        // パラメータ付きSQLコマンドを実行してデータを取得する共通メソッド（SELECT用）
-        
-        public static bool ExecuteReaderWithParameters(
-            string connectionString, // 接続文字列
-            string query, // SQLクエリ
-            Action<SqliteCommand> parameterSetter, // パラメータ設定アクション
-            Action<SqliteDataReader> readerAction) // データリーダー処理アクション
-        {
-            try
-            {
-                //  データベース接続を開く
-                using (var connection = new SqliteConnection(connectionString))
-                {
-                    connection.Open();
-                    // SQLコマンドを作成して実行
-                    using (var command = connection.CreateCommand())
-                    {
-                        command.CommandText = query; // SQLクエリを設定
-                        // parameterSetter は SqliteCommand を期待
-                        parameterSetter?.Invoke((SqliteCommand)command); // パラメータを設定
-                        using (var reader = command.ExecuteReader()) // データリーダーを取得
-                        {
-                            readerAction(reader); // データリーダー処理を実行
-                        }
-                    }
-                }
-                return true; // 成功
-            }
-            catch (Exception ex)
-            {
-                MessageBox.Show(
-                    $"データの取得に失敗しました: {ex.Message}",
-                    "エラー",
-                    MessageBoxButtons.OK,
-                    MessageBoxIcon.Error);
-                return false;
+                return false; // 失敗
             }
         }
 
         // 単一のSQLコマンドを実行する（INSERT/UPDATE/DELETE用）
-        
+
         public static bool ExecuteNonQuery(
             string connectionString,
             string query,
             Action<SqliteCommand> parameters = null, // パラメータ設定アクション
             string successMessage = null) // 成功メッセージ
         {
-            // トランザクション内で実行
-            return ExecuteWithTransaction(
-                connectionString,
-                (connection, transaction) =>
+            try
+            {
+                using (var connection = new SqliteConnection(connectionString))
                 {
-                    // SQLコマンドを作成して実行
+                    connection.Open();
                     using (var command = connection.CreateCommand())
                     {
-                        command.Transaction = transaction; // トランザクションを関連付け
                         command.CommandText = query; // SQLクエリを設定
                         parameters?.Invoke((SqliteCommand)command); // パラメータを設定
                         command.ExecuteNonQuery(); // コマンドを実行
                     }
-                },
-                successMessage // 成功メッセージ
-            );
+                }
+
+
+                if (!string.IsNullOrEmpty(successMessage))
+                    MessageBox.Show(successMessage, "成功", MessageBoxButtons.OK, MessageBoxIcon.Information);
+
+                return true;
+            }
+
+            catch (Exception ex)
+            {
+                MessageBox.Show(
+                    $"データベース操作に失敗しました: {ex.Message}",
+                    "エラー",
+                    MessageBoxButtons.OK,
+                    MessageBoxIcon.Error);
+                return false;
+            }
+           
         }
 
         // InventoryItemsテーブルの全データを保存する
@@ -289,10 +265,11 @@ namespace Inventory_Management_App
             out int InsertedCount,
             out int UpdatedCount)
         {
-            int Inserted = 0;
-            int Updated = 0;
+            int Inserted = 0; // 挿入件数カウンタ
+            int Updated = 0;  // 更新件数カウンタ
 
-            bool Success = ExecuteWithTransaction(
+            // トランザクション内で保存処理を実行
+            bool TransactionSucceeded = ExecuteWithTransaction(
                 ConnectionString,
                 (connection, transaction) =>
                 {
@@ -324,7 +301,7 @@ namespace Inventory_Management_App
                         string Comment = row.Cells[ColumnIndexComment].Value?.ToString() ?? "";
 
                         // 既存データの更新 or 新規挿入
-                        if (row.Tag != null && row.Tag is int id)
+                        if (row.Tag is int id)
                         {
                             // 更新処理
                             using (var UpdateCommand = connection.CreateCommand())
@@ -364,32 +341,25 @@ namespace Inventory_Management_App
 
             InsertedCount = Inserted; // 挿入件数を出力パラメータに設定
             UpdatedCount = Updated; // 更新件数を出力パラメータに設定
-            return Success; // 全体の成功状態を返す
+            return TransactionSucceeded; // 全体の成功状態を返す
         }
 
         // 画像データをデータベースに保存する
         
         public static bool SaveImage(byte[] imageData, int? inventoryItemId = null)
         {
-            return ExecuteWithTransaction(
+            return ExecuteNonQuery(
                 ConnectionString,
-                (connection, transaction) =>
+                @"INSERT INTO Images (InventoryItemId, ImageData, CreatedAt) 
+                  VALUES (@InventoryItemId, @ImageData, @CreatedAt)",
+                
+                (command) =>
                 {
-                    string InsertQuery = @"
-                        INSERT INTO Images (InventoryItemId, ImageData, CreatedAt) 
-                        VALUES (@InventoryItemId, @ImageData, @CreatedAt)";
-
-                    using (var command = connection.CreateCommand())
-                    {
-                        command.Transaction = transaction;
-                        command.CommandText = InsertQuery;
-                        var cmd = (SqliteCommand)command;
-                        cmd.Parameters.AddWithValue("@InventoryItemId",
-                            inventoryItemId.HasValue ? (object)inventoryItemId.Value : DBNull.Value);
-                        cmd.Parameters.AddWithValue("@ImageData", imageData);
-                        cmd.Parameters.AddWithValue("@CreatedAt", DateTime.Now.ToString("yyyy-MM-dd HH:mm:ss"));
-                        cmd.ExecuteNonQuery();
-                    }
+                    var cmd = (SqliteCommand)command;
+                    cmd.Parameters.AddWithValue("@InventoryItemId",
+                        inventoryItemId.HasValue ? (object)inventoryItemId.Value : DBNull.Value);
+                    cmd.Parameters.AddWithValue("@ImageData", imageData);
+                    cmd.Parameters.AddWithValue("@CreatedAt", DateTime.Now.ToString("yyyy-MM-dd HH:mm:ss"));
                 },
                 "画像をデータベースに保存しました。"
             );
@@ -403,29 +373,29 @@ namespace Inventory_Management_App
             List<Image> images = new List<Image>();
 
             // データベースから画像データを取得
-            ExecuteReaderWithParameters(
+            ExecuteReader(
                 ConnectionString,
                 "SELECT ImageData FROM Images WHERE InventoryItemId = @InventoryItemId ORDER BY CreatedAt DESC", // SQLクエリ
-                (command) =>
+                // データリーダー処理
+                (reader) =>
                 {
-                    // パラメータを設定
-                    command.Parameters.AddWithValue("@InventoryItemId", inventoryItemId);
-                },
-                (reader) => // データリーダー処理
-                {
-                    // 画像データを読み込み
                     while (reader.Read())
                     {
-                        // BLOBデータを取得
+                        // 画像データをバイト配列として取得
                         byte[] imageData = (byte[])reader["ImageData"];
                         // バイト配列からImageオブジェクトを作成
-                        using (var ms = new MemoryStream(imageData))
+                        using (MemoryStream ms = new MemoryStream(imageData))
                         {
                             Image img = Image.FromStream(ms); // 元のImageオブジェクト
                             Image clonedImage = new Bitmap(img); // クローンを作成
                             images.Add(clonedImage); // クローンをリストに追加
                         }
                     }
+                },
+                // パラメータ設定
+                (command) =>
+                {
+                    command.Parameters.AddWithValue("@InventoryItemId", inventoryItemId); 
                 }
             );
 
@@ -505,8 +475,7 @@ namespace Inventory_Management_App
             return ExecuteNonQuery(
                 ConnectionString,
                 "DELETE FROM InventoryItems WHERE Id = @Id",
-                (command) => command.Parameters.AddWithValue("@Id", id),
-                null
+                cmd => cmd.Parameters.AddWithValue("@Id", id)
             );
         }
     }

--- a/Inventory Management App/Form1.Designer.cs
+++ b/Inventory Management App/Form1.Designer.cs
@@ -30,120 +30,120 @@ namespace Inventory_Management_App
         /// </summary>
         private void InitializeComponent()
         {
-            this.label1 = new System.Windows.Forms.Label();
-            this.button1 = new System.Windows.Forms.Button();
-            this.button2 = new System.Windows.Forms.Button();
-            this.textBox1 = new System.Windows.Forms.TextBox();
-            this.label2 = new System.Windows.Forms.Label();
-            this.textBox2 = new System.Windows.Forms.TextBox();
-            this.button3 = new System.Windows.Forms.Button();
-            this.button4 = new System.Windows.Forms.Button();
-            this.button5 = new System.Windows.Forms.Button();
-            this.button6 = new System.Windows.Forms.Button();
+            this.QuantityLabel = new System.Windows.Forms.Label();
+            this.PlusButton = new System.Windows.Forms.Button();
+            this.MinusButton = new System.Windows.Forms.Button();
+            this.CountTextBox = new System.Windows.Forms.TextBox();
+            this.TimeLabel = new System.Windows.Forms.Label();
+            this.CommentTextBox = new System.Windows.Forms.TextBox();
+            this.AddButton = new System.Windows.Forms.Button();
+            this.TotalQuantitySelectedButton = new System.Windows.Forms.Button();
+            this.ClearButton = new System.Windows.Forms.Button();
+            this.UpdateButton = new System.Windows.Forms.Button();
             this.SuspendLayout();
             // 
-            // label1
+            // QuantityLabel
             // 
-            this.label1.AutoSize = true;
-            this.label1.Location = new System.Drawing.Point(30, 30);
-            this.label1.Name = "label1";
-            this.label1.Size = new System.Drawing.Size(37, 15);
-            this.label1.TabIndex = 0;
-            this.label1.Text = "数量";
+            this.QuantityLabel.AutoSize = true;
+            this.QuantityLabel.Location = new System.Drawing.Point(30, 30);
+            this.QuantityLabel.Name = "QuantityLabel";
+            this.QuantityLabel.Size = new System.Drawing.Size(37, 15);
+            this.QuantityLabel.TabIndex = 0;
+            this.QuantityLabel.Text = "数量";
             // 
-            // button1
+            // PlusButton
             // 
-            this.button1.Location = new System.Drawing.Point(200, 27);
-            this.button1.Name = "button1";
-            this.button1.Size = new System.Drawing.Size(40, 27);
-            this.button1.TabIndex = 2;
-            this.button1.Text = "+";
-            this.button1.UseVisualStyleBackColor = true;
+            this.PlusButton.Location = new System.Drawing.Point(200, 27);
+            this.PlusButton.Name = "PlusButton";
+            this.PlusButton.Size = new System.Drawing.Size(40, 27);
+            this.PlusButton.TabIndex = 2;
+            this.PlusButton.Text = "+";
+            this.PlusButton.UseVisualStyleBackColor = true;
             // 
-            // button2
+            // MinusButton
             // 
-            this.button2.Location = new System.Drawing.Point(250, 27);
-            this.button2.Name = "button2";
-            this.button2.Size = new System.Drawing.Size(40, 27);
-            this.button2.TabIndex = 3;
-            this.button2.Text = "-";
-            this.button2.UseVisualStyleBackColor = true;
+            this.MinusButton.Location = new System.Drawing.Point(250, 27);
+            this.MinusButton.Name = "MinusButton";
+            this.MinusButton.Size = new System.Drawing.Size(40, 27);
+            this.MinusButton.TabIndex = 3;
+            this.MinusButton.Text = "-";
+            this.MinusButton.UseVisualStyleBackColor = true;
             // 
-            // textBox1
+            // CountTextBox
             // 
-            this.textBox1.Location = new System.Drawing.Point(85, 28);
-            this.textBox1.Name = "textBox1";
-            this.textBox1.Size = new System.Drawing.Size(100, 22);
-            this.textBox1.TabIndex = 1;
+            this.CountTextBox.Location = new System.Drawing.Point(85, 28);
+            this.CountTextBox.Name = "CountTextBox";
+            this.CountTextBox.Size = new System.Drawing.Size(100, 22);
+            this.CountTextBox.TabIndex = 1;
             // 
-            // label2
+            // TimeLabel
             // 
-            this.label2.AutoSize = true;
-            this.label2.Location = new System.Drawing.Point(30, 65);
-            this.label2.Name = "label2";
-            this.label2.Size = new System.Drawing.Size(0, 15);
-            this.label2.TabIndex = 4;
+            this.TimeLabel.AutoSize = true;
+            this.TimeLabel.Location = new System.Drawing.Point(30, 65);
+            this.TimeLabel.Name = "TimeLabel";
+            this.TimeLabel.Size = new System.Drawing.Size(0, 15);
+            this.TimeLabel.TabIndex = 4;
             // 
-            // textBox2
+            // CommentTextBox
             // 
-            this.textBox2.Location = new System.Drawing.Point(95, 56);
-            this.textBox2.Multiline = true;
-            this.textBox2.Name = "textBox2";
-            this.textBox2.Size = new System.Drawing.Size(145, 32);
-            this.textBox2.TabIndex = 5;
-            this.textBox2.Text = "コメント";
+            this.CommentTextBox.Location = new System.Drawing.Point(95, 56);
+            this.CommentTextBox.Multiline = true;
+            this.CommentTextBox.Name = "CommentTextBox";
+            this.CommentTextBox.Size = new System.Drawing.Size(145, 32);
+            this.CommentTextBox.TabIndex = 5;
+            this.CommentTextBox.Text = "コメント";
             // 
-            // button3
+            // AddButton
             // 
-            this.button3.Location = new System.Drawing.Point(250, 56);
-            this.button3.Name = "button3";
-            this.button3.Size = new System.Drawing.Size(100, 30);
-            this.button3.TabIndex = 7;
-            this.button3.Text = "追加";
-            this.button3.UseVisualStyleBackColor = true;
+            this.AddButton.Location = new System.Drawing.Point(250, 56);
+            this.AddButton.Name = "AddButton";
+            this.AddButton.Size = new System.Drawing.Size(100, 30);
+            this.AddButton.TabIndex = 7;
+            this.AddButton.Text = "追加";
+            this.AddButton.UseVisualStyleBackColor = true;
             // 
-            // button4
+            // TotalQuantitySelectedButton
             // 
-            this.button4.Location = new System.Drawing.Point(200, 504);
-            this.button4.Name = "button4";
-            this.button4.Size = new System.Drawing.Size(173, 33);
-            this.button4.TabIndex = 8;
-            this.button4.Text = "選択された合計数量";
-            this.button4.UseVisualStyleBackColor = true;
+            this.TotalQuantitySelectedButton.Location = new System.Drawing.Point(200, 504);
+            this.TotalQuantitySelectedButton.Name = "TotalQuantitySelectedButton";
+            this.TotalQuantitySelectedButton.Size = new System.Drawing.Size(173, 33);
+            this.TotalQuantitySelectedButton.TabIndex = 8;
+            this.TotalQuantitySelectedButton.Text = "選択された合計数量";
+            this.TotalQuantitySelectedButton.UseVisualStyleBackColor = true;
             // 
-            // button5
+            // ClearButton
             // 
-            this.button5.Location = new System.Drawing.Point(33, 504);
-            this.button5.Name = "button5";
-            this.button5.Size = new System.Drawing.Size(117, 33);
-            this.button5.TabIndex = 9;
-            this.button5.Text = "クリア";
-            this.button5.UseVisualStyleBackColor = true;
+            this.ClearButton.Location = new System.Drawing.Point(33, 504);
+            this.ClearButton.Name = "ClearButton";
+            this.ClearButton.Size = new System.Drawing.Size(117, 33);
+            this.ClearButton.TabIndex = 9;
+            this.ClearButton.Text = "クリア";
+            this.ClearButton.UseVisualStyleBackColor = true;
             // 
-            // button6
+            // UpdateButton
             // 
-            this.button6.Location = new System.Drawing.Point(536, 30);
-            this.button6.Name = "button6";
-            this.button6.Size = new System.Drawing.Size(149, 30);
-            this.button6.TabIndex = 10;
-            this.button6.Text = "更新";
-            this.button6.UseVisualStyleBackColor = true;
+            this.UpdateButton.Location = new System.Drawing.Point(536, 30);
+            this.UpdateButton.Name = "UpdateButton";
+            this.UpdateButton.Size = new System.Drawing.Size(149, 30);
+            this.UpdateButton.TabIndex = 10;
+            this.UpdateButton.Text = "更新";
+            this.UpdateButton.UseVisualStyleBackColor = true;
             // 
             // InventoryQuantityForm
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 15F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.ClientSize = new System.Drawing.Size(800, 656);
-            this.Controls.Add(this.button6);
-            this.Controls.Add(this.button5);
-            this.Controls.Add(this.button4);
-            this.Controls.Add(this.button3);
-            this.Controls.Add(this.textBox2);
-            this.Controls.Add(this.label2);
-            this.Controls.Add(this.textBox1);
-            this.Controls.Add(this.button2);
-            this.Controls.Add(this.button1);
-            this.Controls.Add(this.label1);
+            this.Controls.Add(this.UpdateButton);
+            this.Controls.Add(this.ClearButton);
+            this.Controls.Add(this.TotalQuantitySelectedButton);
+            this.Controls.Add(this.AddButton);
+            this.Controls.Add(this.CommentTextBox);
+            this.Controls.Add(this.TimeLabel);
+            this.Controls.Add(this.CountTextBox);
+            this.Controls.Add(this.MinusButton);
+            this.Controls.Add(this.PlusButton);
+            this.Controls.Add(this.QuantityLabel);
             this.Name = "InventoryQuantityForm";
             this.Text = "Form1";
             this.ResumeLayout(false);
@@ -153,16 +153,16 @@ namespace Inventory_Management_App
 
         #endregion
 
-        private System.Windows.Forms.Label label1;
-        private System.Windows.Forms.Button button1;
-        private System.Windows.Forms.Button button2;
-        private System.Windows.Forms.TextBox textBox1;
-        private System.Windows.Forms.Label label2;
-        private System.Windows.Forms.TextBox textBox2;
-        private System.Windows.Forms.Button button3;
-        private System.Windows.Forms.Button button4;
-        private System.Windows.Forms.Button button5;
-        private System.Windows.Forms.Button button6;
+        private System.Windows.Forms.Label QuantityLabel;
+        private System.Windows.Forms.Button PlusButton;
+        private System.Windows.Forms.Button MinusButton;
+        private System.Windows.Forms.TextBox CountTextBox;
+        private System.Windows.Forms.Label TimeLabel;
+        private System.Windows.Forms.TextBox CommentTextBox;
+        private System.Windows.Forms.Button AddButton;
+        private System.Windows.Forms.Button TotalQuantitySelectedButton;
+        private System.Windows.Forms.Button ClearButton;
+        private System.Windows.Forms.Button UpdateButton;
     }
 }
 

--- a/Inventory Management App/Form1.cs
+++ b/Inventory Management App/Form1.cs
@@ -1,11 +1,9 @@
 ﻿using Microsoft.Data.Sqlite;
 using System;
 using System.Collections.Generic;
-using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.Data;
 using System.Data.Common;
-using System.Data.SqlClient;
 using System.Data.SQLite;
 using System.Drawing;
 using System.IO;
@@ -15,7 +13,6 @@ using System.Text;
 using System.Threading.Tasks;
 using System.Windows.Forms;
 using System.Windows.Threading;
-using System.Xml.Linq;
 using static System.Windows.Forms.VisualStyles.VisualStyleElement.TaskbarClock;
 
 namespace Inventory_Management_App
@@ -37,6 +34,7 @@ namespace Inventory_Management_App
         private const int COLUMN_INDEX_QUANTITY = 2;
         private const int COLUMN_INDEX_COMMENT = 3;
         private const int COLUMN_INDEX_DELETE = 4;
+        private const int COLUMN_INDEX_DETAIL = 5; // 追加：詳細ボタン列のインデックス
 
         // 現在の数量を保持する変数
         private int CurrentAmount = DEFAULT_CURRENT_AMOUNT;
@@ -48,8 +46,8 @@ namespace Inventory_Management_App
         private DataGridView InventoryDataGridView;
 
         // データベース初期化
-        private string DbPath;
-        private string ConnectionString;
+        private string dbPath;
+        private string connectionString;
 
         public InventoryQuantityForm()
         {
@@ -108,139 +106,26 @@ namespace Inventory_Management_App
         // データベース初期化
         private void InitializeDatabase()
         {
-            try
+            // データベースファイルのパス
+            dbPath = Path.Combine(
+                Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+                "InventoryData.db"
+            );
+            connectionString = $"Data Source={dbPath};";
+
+            // データベースファイルが存在しない場合は作成
+            if (!File.Exists(dbPath))
             {
-                // データベースファイルのパス設定
-                DbPath = Path.Combine(
-                    Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
-                    "InventoryData.db"
-                );
-                ConnectionString = $"Data Source={DbPath};";
-
-                // データベースファイルが存在しない場合のみ作成
-                if (File.Exists(DbPath) == false)
-                {
-                    // 空ファイルを作成
-                    using (File.Create(DbPath))
-                    {
-                        // DB作成成功メッセージ
-                        MessageBox.Show(
-                            $"データベースファイルを作成しました。{DbPath}",
-                            "DB作成完了",
-                            MessageBoxButtons.OK,
-                            MessageBoxIcon.Information
-                        );
-                    }
-                }
-
-                // テーブルの存在確認
-                if (!TableExists("InventoryItems"))
-                {
-                    // テーブルが存在しない場合のみ作成
-                    bool TableCreate = CreateInventoryTable();
-
-                    // テーブル作成結果に応じてメッセージを表示
-                    if (TableCreate)
-                    {
-                        // テーブル作成成功メッセージ
-                        MessageBox.Show(
-                            "テーブル「InventoryItems」を作成しました。",
-                            "テーブル作成完了",
-                            MessageBoxButtons.OK,
-                            MessageBoxIcon.Information
-                        );
-                    }
-                    else
-                    {
-                        // テーブル作成失敗メッセージ
-                        MessageBox.Show(
-                            "テーブル「InventoryItems」の作成に失敗しました。",
-                            "エラー",
-                            MessageBoxButtons.OK,
-                            MessageBoxIcon.Error
-                        );
-                    }
-                }
+                // 空ファイルを作成
+                using (File.Create(dbPath)) { }
             }
-            catch (Exception ex)
+
+            // テーブル作成
+            using (var connection = new SqliteConnection(connectionString))
             {
-                // デバッグ: エラー詳細
-                System.Diagnostics.Debug.WriteLine($"[ERROR] メッセージ: {ex.Message}");
-
-                MessageBox.Show(
-                    $"データベース初期化エラー:\n{ex.Message}",
-                    "エラー",
-                    MessageBoxButtons.OK,
-                    MessageBoxIcon.Error
-                );
-            }
-        }
-
-        // テーブル存在確認メソッド
-        private bool TableExists(string tableName)
-        {
-            try
-            {
-                using (SqliteConnection Connection = new SqliteConnection(ConnectionString))
-                {
-                    Connection.Open();
-                    // デバッグ: 接続成功
-                    System.Diagnostics.Debug.WriteLine($"[DEBUG] DB接続成功: {ConnectionString}");
-
-                    string CheckQuery = @"
-                        SELECT name
-                        FROM sqlite_master
-                        WHERE type = 'table' 
-                        AND name = @TableName";
-
-                    using (SqliteCommand Command = new SqliteCommand(CheckQuery, Connection))
-                    {
-                        Command.Parameters.AddWithValue("@TableName", tableName);
-
-                        try
-                        {
-                            // 1. object型で宣言
-                            object result = Command.ExecuteScalar();
-                            // 2. nullチェック
-                            if (result != null)
-                            {
-                                return true;   // テーブルが存在
-                            }
-                            else
-                            {
-                                return false;  // テーブルが存在しない
-                            }
-                        }
-                        catch (Exception ex)
-                        {
-                            // デバッグ: エラー詳細
-                            System.Diagnostics.Debug.WriteLine($"[ERROR] TableExists ExecuteScalar: {ex.Message}");
-                            throw new Exception("テーブル存在確認クエリの実行に失敗しました。", ex); 
-                        }
-
-
-                    }
-                }
-            }
-            catch (Exception ex)
-            {
-                // 失敗した場合は詳細をデバッグ出力して false を返す
-                System.Diagnostics.Debug.WriteLine($"[ERROR] CreateInventoryTable: {ex.Message}");
-                throw new Exception("テーブル存在確認に失敗しました。", ex); 
-            }
-        }
-
-        // InventoryItemsテーブルを作成,bool型を返すように修正
-        private bool CreateInventoryTable()
-        {
-            try
-            {
-                using (SqliteConnection Connection = new SqliteConnection(ConnectionString))
-                {
-                    Connection.Open();
-
-                    string CreateTableQuery = @"
-                    CREATE TABLE InventoryItems (
+                connection.Open();
+                string createTableQuery = @"
+                    CREATE TABLE IF NOT EXISTS InventoryItems (
                         Id INTEGER PRIMARY KEY AUTOINCREMENT,
                         IsChecked INTEGER NOT NULL DEFAULT 0,
                         Time TEXT NOT NULL,
@@ -248,57 +133,44 @@ namespace Inventory_Management_App
                         Comment TEXT
                     )";
 
-                
-
-                    using (SqliteCommand Command = new SqliteCommand(CreateTableQuery, Connection))
-                    {
-                        Command.ExecuteNonQuery();
-                    }
+                using (var command = new SqliteCommand(createTableQuery, connection))
+                {
+                    command.ExecuteNonQuery();
                 }
-                return true; // 成功
             }
-            catch (Exception ex)
-            {
-                // 失敗した場合は詳細をデバッグ出力して false を返す
-                System.Diagnostics.Debug.WriteLine($"[ERROR] CreateInventoryTable: {ex.Message}");
-                return false; // 失敗
-            }
-
         }
-
         // データベースからデータを読み込む
         private void LoadDataFromDatabase()
         {
             InventoryDataGridView.Rows.Clear();
 
-            using (SqliteConnection Connectionn = new SqliteConnection(ConnectionString))
+            using (var connection = new SqliteConnection(connectionString))
             {
-                // 接続開始
-                Connectionn.Open();
-                string SelectQuery = "SELECT * FROM InventoryItems ORDER BY Id";
+                connection.Open();
+                string query = "SELECT * FROM InventoryItems ORDER BY Id";
 
-                using (SqliteCommand Command = new SqliteCommand(SelectQuery, Connectionn))
-                using (SqliteDataReader Reader = Command.ExecuteReader())
+                using (var command = new SqliteCommand(query, connection))
+                using (var reader = command.ExecuteReader())
                 {
-                    while (Reader.Read())
+                    while (reader.Read())
                     {
-                        int Id = Reader.GetInt32(0);
-                        bool IsChecked = Reader.GetInt32(1) == 1;
-                        string Time = Reader.GetString(2);
-                        int Quantity = Reader.GetInt32(3);
-                        string Comment = Reader.IsDBNull(4) ? "" : Reader.GetString(4);
+                        int id = reader.GetInt32(0);
+                        bool isChecked = reader.GetInt32(1) == 1;
+                        string time = reader.GetString(2);
+                        int quantity = reader.GetInt32(3);
+                        string comment = reader.IsDBNull(4) ? "" : reader.GetString(4);
 
                         // DataGridViewに行を追加
-                        int RowIndex = InventoryDataGridView.Rows.Add(
-                            IsChecked,
-                            Time,
-                            Quantity.ToString("N0"),
-                            Comment,
+                        int rowIndex = InventoryDataGridView.Rows.Add(
+                            isChecked,
+                            time,
+                            quantity.ToString("N0"),
+                            comment,
                             ""
                         );
 
                         // 行のTagにIDを保存
-                        InventoryDataGridView.Rows[RowIndex].Tag = Id;
+                        InventoryDataGridView.Rows[rowIndex].Tag = id;
                     }
                 }
             }
@@ -434,6 +306,15 @@ namespace Inventory_Management_App
             deleteColumn.Width = 100;
             InventoryDataGridView.Columns.Add(deleteColumn);
 
+            // 詳細ボタン列
+            DataGridViewButtonColumn detailColumn = new DataGridViewButtonColumn();
+            detailColumn.HeaderText = "詳細";
+            detailColumn.Name = "Detail";
+            detailColumn.Text = "詳細";
+            detailColumn.UseColumnTextForButtonValue = true;
+            detailColumn.Width = 100;
+            InventoryDataGridView.Columns.Add(detailColumn);
+
             // イベント登録
             InventoryDataGridView.CellContentClick += InventoryDataGridView_CellContentClick;
 
@@ -456,38 +337,43 @@ namespace Inventory_Management_App
                 InventoryDataGridView.EndEdit(); // チェックボックスの状態を確定(編集モードを終了)
                 UpdateRowBackgroundColors();
             }
+            // 詳細ボタンがクリックされた場合
+            else if(e.ColumnIndex == COLUMN_INDEX_DETAIL)
+            {
+                DetailRow(e.RowIndex);
+            }
         }
 
         // 削除メソッドを追加
         private void DeleteRow(int RowIndex)
         {
             // 削除確認ダイアログを表示
-            DialogResult Result = MessageBox.Show("この行を削除しますか？", "確認", MessageBoxButtons.YesNo, MessageBoxIcon.Question);
-            
-            // 
-            DataGridViewRow row = InventoryDataGridView.Rows[RowIndex];
-            if (Result == DialogResult.Yes)
+            var result = MessageBox.Show("この行を削除しますか？", "確認", MessageBoxButtons.YesNo, MessageBoxIcon.Question);
+            if (result == DialogResult.Yes)
             {
-                // TagにIDがある場合は、DBからも削除
-                if (row.Tag != null && row.Tag is int id)
-                {
-                    using (SqliteConnection connection = new SqliteConnection(ConnectionString))
-                    {
-                        connection.Open();
-                        string deleteQuery = "DELETE FROM InventoryItems WHERE Id = @Id";
-
-                        using (SqliteCommand command = new SqliteCommand(deleteQuery, connection))
-                        {
-                            command.Parameters.AddWithValue("@Id", id);
-                            command.ExecuteNonQuery();
-                        }
-                    }
-                }
-                InventoryDataGridView.Rows.RemoveAt(RowIndex); //DataGridViewから削除
+                InventoryDataGridView.Rows.RemoveAt(RowIndex);
                 UpdateRowBackgroundColors();
-
-                MessageBox.Show("削除しました。", "完了", MessageBoxButtons.OK, MessageBoxIcon.Information);
             }
+        }
+
+        // 詳細ボタン（リストビューの現在時刻/数量/コメントが表示）
+        private void DetailRow(int RowIndex)
+        {
+            // 行データを取得
+            DataGridViewRow row = InventoryDataGridView.Rows[RowIndex];
+            string time = row.Cells[COLUMN_INDEX_TIME].Value?.ToString() ?? "";
+            string quantity = row.Cells[COLUMN_INDEX_QUANTITY].Value?.ToString() ?? ""; 
+            string comment = row.Cells[COLUMN_INDEX_COMMENT].Value?.ToString() ?? "";
+            // 詳細メッセージを作成
+            string detailMessage = $"時刻: {time}\n数量: {quantity}\nコメント: {comment}";
+            // メッセージボックスで表示(デバッグ用）
+            //MessageBox.Show(detailMessage, "行の詳細", MessageBoxButtons.OK, MessageBoxIcon.Information);
+            
+            // 画面を切り替えて表示
+            // DetailFormのインスタンスを作成し、データを渡す
+            Form detailForm = new Form2(time, quantity, comment);
+            detailForm.Show();
+
         }
 
         // 在庫追加ボタン
@@ -518,6 +404,7 @@ namespace Inventory_Management_App
             {
                 DataGridViewRow Row = InventoryDataGridView.Rows[i];
 
+                // チェックボックスの値を取得
                 // 合計計算に含めるかどうかを示すチェックボックスの値を取得
                 bool IncludedInTotal = Row.Cells[COLUMN_INDEX_CHECKBOX].Value is bool CheckBoxcellValue && CheckBoxcellValue;
 
@@ -566,136 +453,86 @@ namespace Inventory_Management_App
             MessageBox.Show($"選択された合計数量: {TotalOfCheckedRows:N0}", "合計数量", MessageBoxButtons.OK, MessageBoxIcon.Information);
         }
 
-        // クリアボタンがクリックされたときの処理
         private void ClearButton_Click(object sender, EventArgs e)
         {
             // 削除確認ダイアログを表示
-            DialogResult Result = MessageBox.Show("データをクリアしますか？", "確認", MessageBoxButtons.YesNo, MessageBoxIcon.Question);
-            
+            var result = MessageBox.Show("データをクリアしますか？", "確認", MessageBoxButtons.YesNo, MessageBoxIcon.Question);
             // 「はい」が選択された場合のみ削除
-            if (Result == DialogResult.Yes)
+            if (result == DialogResult.Yes)
             {
-                // DBから全削除
-                using (SqliteConnection Connection = new SqliteConnection(ConnectionString))
-                {
-                    Connection.Open();
-                    string DeleteQuery = "DELETE FROM InventoryItems";
-
-                    using (SqliteCommand command = new SqliteCommand(DeleteQuery, Connection))
-                    {
-                        command.ExecuteNonQuery();
-                    }
-                }
-
-                // DataGridViewをクリア
+                // DataGridViewの全行を削除
                 InventoryDataGridView.Rows.Clear();
-
-                MessageBox.Show("全てのデータをクリアしました。", "完了", MessageBoxButtons.OK, MessageBoxIcon.Information);
-
             }
         }
 
-        // 更新ボタンがクリックされたときの処理(DBに登録）
+        // 更新ボタン(DBに登録）
         private void UpdateButton_Click(object sender, EventArgs e)
         {
-
-            DialogResult Result = MessageBox.Show("DataGridViewの全データをデータベースに保存しますか？", "保存確認",
+            var result = MessageBox.Show("DataGridViewの全データをデータベースに保存しますか？", "保存確認",
                 MessageBoxButtons.YesNo, MessageBoxIcon.Question);
 
-            if (Result == DialogResult.Yes)
+            if (result == DialogResult.Yes)
             {
-                try
-                {
-                    using (SqliteConnection Connection = new SqliteConnection(ConnectionString))
+                    using (var connection = new SqliteConnection(connectionString))
                     {
-                        // 接続開始
-                        Connection.Open();
+                        connection.Open();
 
                         // トランザクション開始
-                        using (SqliteTransaction Transaction = Connection.BeginTransaction())
+                        using (var transaction = connection.BeginTransaction())
                         {
-                            // UPDATE用クエリ（既存レコードを更新）
-                            string UpdateQuery = @"
-                                    UPDATE InventoryItems
-                                    SET IsChecked = @IsChecked,
-                                        Time = @Time,
-                                        Quantity = @Quantity,
-                                        Comment = @Comment
-                                    WHERE Id = @Id";
-
-                            // INSERT用クエリ（新規レコードを挿入）
-                            string InsertQuery = @"
-                                        INSERT INTO InventoryItems (IsChecked, Time, Quantity, Comment)
-                                        VALUES (@IsChecked, @Time, @Quantity, @Comment)";
-
-
-                            foreach (DataGridViewRow row in InventoryDataGridView.Rows)
-                            {
-                                // チェックボックスの値を取得
-                                bool IsChecked = row.Cells[COLUMN_INDEX_CHECKBOX].Value is bool checkValue && checkValue;
-
-                                // 時刻を取得
-                                string Time = row.Cells[COLUMN_INDEX_TIME].Value.ToString() ?? DateTime.Now.ToString("HH:mm:ss");
-
-                                // 数量を取得（カンマを除去して数値に変換）
-                                string QuantityText = row.Cells[COLUMN_INDEX_QUANTITY].Value.ToString()?.Replace(",", "");
-                                int Quantity = int.TryParse(QuantityText, out int qty) ? qty : 0;
-
-                                // コメントを取得
-                                string Comment = row.Cells[COLUMN_INDEX_COMMENT].Value.ToString();
-
-                                // 行のTagにIDがある場合はUPDATE、ない場合はINSERT
-                                if (row.Tag != null && row.Tag is int id)
+                                // 既存データを全削除
+                                string deleteQuery = "DELETE FROM InventoryItems";
+                                using (var deleteCommand = new SqliteCommand(deleteQuery, connection, transaction))
                                 {
-                                    // 既存レコードを更新
-                                    using (SqliteCommand UpdateCommand = new SqliteCommand(UpdateQuery, Connection, Transaction))
+                                    deleteCommand.ExecuteNonQuery();
+                                }
+
+                                // DataGridViewの全データを挿入
+                                string insertQuery = @"
+                                    INSERT INTO InventoryItems (IsChecked, Time, Quantity, Comment)
+                                    VALUES (@IsChecked, @Time, @Quantity, @Comment)";
+
+                                int savedCount = 0;
+
+                                foreach (DataGridViewRow row in InventoryDataGridView.Rows)
+                                {
+                                    // チェックボックスの値を取得
+                                    bool isChecked = row.Cells[COLUMN_INDEX_CHECKBOX].Value is bool checkValue && checkValue;
+
+                                    // 時刻を取得
+                                    string time = row.Cells[COLUMN_INDEX_TIME].Value?.ToString() ?? DateTime.Now.ToString("HH:mm:ss");
+
+                                    // 数量を取得（カンマを除去して数値に変換）
+                                    string quantityText = row.Cells[COLUMN_INDEX_QUANTITY].Value?.ToString()?.Replace(",", "") ?? "0";
+                                    int quantity = int.TryParse(quantityText, out int qty) ? qty : 0;
+
+                                    // コメントを取得
+                                    string comment = row.Cells[COLUMN_INDEX_COMMENT].Value?.ToString() ?? "";
+
+                                    // データベースに挿入
+                                    using (var insertCommand = new SqliteCommand(insertQuery, connection, transaction))
                                     {
-                                        UpdateCommand.Parameters.AddWithValue("@Id", id);
-                                        UpdateCommand.Parameters.AddWithValue("@IsChecked", IsChecked ? 1 : 0);
-                                        UpdateCommand.Parameters.AddWithValue("@Time", Time);
-                                        UpdateCommand.Parameters.AddWithValue("@Quantity", Quantity);
-                                        UpdateCommand.Parameters.AddWithValue("@Comment", Comment);
+                                        insertCommand.Parameters.AddWithValue("@IsChecked", isChecked ? 1 : 0);
+                                        insertCommand.Parameters.AddWithValue("@Time", time);
+                                        insertCommand.Parameters.AddWithValue("@Quantity", quantity);
+                                        insertCommand.Parameters.AddWithValue("@Comment", comment);
 
-                                        UpdateCommand.ExecuteNonQuery();
-
+                                        insertCommand.ExecuteNonQuery();
+                                        savedCount++;
                                     }
                                 }
-                                else
-                                {
-                                    // 新規レコードを挿入
-                                    using (SqliteCommand InsertCommand = new SqliteCommand(InsertQuery, Connection, Transaction))
-                                    {
-                                        InsertCommand.Parameters.AddWithValue("@IsChecked", IsChecked ? 1 : 0);
-                                        InsertCommand.Parameters.AddWithValue("@Time", Time);
-                                        InsertCommand.Parameters.AddWithValue("@Quantity", Quantity);
-                                        InsertCommand.Parameters.AddWithValue("@Comment", Comment);
 
-                                        InsertCommand.ExecuteNonQuery();
+                                // コミット
+                                transaction.Commit();
 
-                                    }
-                                }
-                            }
+                                // データを再読み込み
+                                LoadDataFromDatabase();
 
-                            // コミット
-                            Transaction.Commit();
-
-                            // データを再読み込み
-                            LoadDataFromDatabase();
+                                MessageBox.Show($"データベースに{savedCount}件のデータを保存しました。", "保存完了",
+                                    MessageBoxButtons.OK, MessageBoxIcon.Information);
                         }
                     }
-                }
-                catch (Exception ex)
-                {
-                    // 
-                    MessageBox.Show(
-                    $"データ読込エラー:\n{ex.Message}",
-                    "エラー",
-                    MessageBoxButtons.OK,
-                    MessageBoxIcon.Error
-                );
-                }
             }
         }
     }
 }
-

--- a/Inventory Management App/Form1.cs
+++ b/Inventory Management App/Form1.cs
@@ -1,25 +1,17 @@
 ﻿using Microsoft.Data.Sqlite;
 using System;
 using System.Collections.Generic;
-using System.ComponentModel;
-using System.Data;
-using System.Data.Common;
-using System.Data.SQLite;
 using System.Drawing;
 using System.IO;
 using System.Linq;
-using System.Reflection.Emit;
 using System.Text;
-using System.Threading.Tasks;
 using System.Windows.Forms;
 using System.Windows.Threading;
-using static System.Windows.Forms.VisualStyles.VisualStyleElement.TaskbarClock;
 
 namespace Inventory_Management_App
 {
     public partial class InventoryQuantityForm : Form
     {
-
         // 定数の設定
         // 最大値の設定
         private const int MAX_CURRENT_AMOUNT = 9999;
@@ -34,148 +26,70 @@ namespace Inventory_Management_App
         private const int COLUMN_INDEX_QUANTITY = 2;
         private const int COLUMN_INDEX_COMMENT = 3;
         private const int COLUMN_INDEX_DELETE = 4;
-        private const int COLUMN_INDEX_DETAIL = 5; // 追加：詳細ボタン列のインデックス
+        private const int COLUMN_INDEX_DETAIL = 5; // 詳細ボタン列
 
         // 現在の数量を保持する変数
         private int CurrentAmount = DEFAULT_CURRENT_AMOUNT;
 
         // 時刻
-        private DispatcherTimer timer;
+        //private DispatcherTimer timer;
+        // ↓修正案
+        private System.Windows.Forms.Timer timer; // WinForms用タイマー
 
         // 在庫リスト表示用DataGridView
         private DataGridView InventoryDataGridView;
-
-        // データベース初期化
-        private string dbPath;
-        private string connectionString;
 
         public InventoryQuantityForm()
         {
             InitializeComponent();
 
             // 初期値を設定,数値→文字形式に変換
-            textBox1.Text = DEFAULT_CURRENT_AMOUNT.ToString();
-
+            CountTextBox.Text = DEFAULT_CURRENT_AMOUNT.ToString();
 
             // タイマのインスタンスを生成
-            timer = new DispatcherTimer();
-            // 1秒ごとにイベントを発生させます。
-            timer.Interval = TimeSpan.FromSeconds(1);
-            // タイマーのTickイベントにTimer_Tickメソッドを関連付け
-            // timer.Tick:イベント
-            // Timer_Tick:メソッド
-            timer.Tick += Timer_Tick;
-            // timerをスタートさせます。
-            timer.Start();
+            //timer = new DispatcherTimer();
+            //// 1秒ごとにイベントを発生させます。
+            //timer.Interval = TimeSpan.FromSeconds(1);
+            //// タイマーのTickイベントにTimer_Tickメソッドを関連付け
+            //// timer.Tick:イベント
+            //// Timer_Tick:メソッド
+            //timer.Tick += Timer_Tick;
+            //// timerをスタートさせます。
+            //timer.Start();
 
-            // button1（+ボタン）のイベント設定
-            button1.Click += PlusButton_Click;
+            //↓修正案(問題なければ、こちらを採用。上記は削除する予定）
+            //タイマーのインスタンスを生成（WinForms.Timerを使用）
+            timer = new System.Windows.Forms.Timer();
+             timer.Interval = 1000; // 1秒（ミリ秒）
+             timer.Tick += Timer_Tick;
+             timer.Start();
 
-            // button2（-ボタン）のイベント設定
-            button2.Click += MinusButton_Click;
-
-            // テキストボックスの手入力対応
-            textBox1.Leave += TextBox1_Leave; // フォーカスが外れた時
+            // イベント設定
+            PlusButton.Click += PlusButton_Click; // +ボタン
+            MinusButton.Click += MinusButton_Click; // -ボタン
+            CountTextBox.Leave += TextBox1_Leave; // フォーカスが外れた時
+            AddButton.Click += AddButton_Click; // 追加ボタン
+            TotalQuantitySelectedButton.Click += TotalQuantity_Click; // 合計数量ボタン
+            ClearButton.Click += ClearButton_Click; // クリアボタン
+            UpdateButton.Click += UpdateButton_Click; // 更新ボタン
 
             // 3桁区切りのカンマ付きで表示
             CommaValue();
 
-            // button3（追加ボタン）のイベント設定
-            button3.Click += AddButton_Click;
-
-            // 合計数量ボタンの設定
-            button4.Click += TotalQuantity_Click;
-
-            // リストビューの設定
+            // リストビュー（DataGridView）の設定
             SetupInventoryDataGridView();
 
-            // 合計数量ボタンの設定
-            button5.Click += ClearButton_Click;
-
-            // 更新ボタンの設定
-            button6.Click += UpdateButton_Click;
-
             // データベース初期化
-            InitializeDatabase();
+            DatabaseHelper.InitializeDatabase();
 
             // DBからデータを読み込んで表示
             LoadDataFromDatabase();
-
         }
 
-        // データベース初期化
-        private void InitializeDatabase()
-        {
-            // データベースファイルのパス
-            dbPath = Path.Combine(
-                Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
-                "InventoryData.db"
-            );
-            connectionString = $"Data Source={dbPath};";
-
-            // データベースファイルが存在しない場合は作成
-            if (!File.Exists(dbPath))
-            {
-                // 空ファイルを作成
-                using (File.Create(dbPath)) { }
-            }
-
-            // テーブル作成
-            using (var connection = new SqliteConnection(connectionString))
-            {
-                connection.Open();
-                string createTableQuery = @"
-                    CREATE TABLE IF NOT EXISTS InventoryItems (
-                        Id INTEGER PRIMARY KEY AUTOINCREMENT,
-                        IsChecked INTEGER NOT NULL DEFAULT 0,
-                        Time TEXT NOT NULL,
-                        Quantity INTEGER NOT NULL,
-                        Comment TEXT
-                    )";
-
-                using (var command = new SqliteCommand(createTableQuery, connection))
-                {
-                    command.ExecuteNonQuery();
-                }
-            }
-        }
         // データベースからデータを読み込む
         private void LoadDataFromDatabase()
         {
-            InventoryDataGridView.Rows.Clear();
-
-            using (var connection = new SqliteConnection(connectionString))
-            {
-                connection.Open();
-                string query = "SELECT * FROM InventoryItems ORDER BY Id";
-
-                using (var command = new SqliteCommand(query, connection))
-                using (var reader = command.ExecuteReader())
-                {
-                    while (reader.Read())
-                    {
-                        int id = reader.GetInt32(0);
-                        bool isChecked = reader.GetInt32(1) == 1;
-                        string time = reader.GetString(2);
-                        int quantity = reader.GetInt32(3);
-                        string comment = reader.IsDBNull(4) ? "" : reader.GetString(4);
-
-                        // DataGridViewに行を追加
-                        int rowIndex = InventoryDataGridView.Rows.Add(
-                            isChecked,
-                            time,
-                            quantity.ToString("N0"),
-                            comment,
-                            ""
-                        );
-
-                        // 行のTagにIDを保存
-                        InventoryDataGridView.Rows[rowIndex].Tag = id;
-                    }
-                }
-            }
-
-            // 背景色を更新
+            DatabaseHelper.LoadInventoryDataToGridView(InventoryDataGridView);
             UpdateRowBackgroundColors();
         }
 
@@ -186,7 +100,6 @@ namespace Inventory_Management_App
             if (CurrentAmount < MAX_CURRENT_AMOUNT)
             {
                 CurrentAmount++;
-                textBox1.Text = CurrentAmount.ToString(); // 変換
                 CommaValue();
             }
         }
@@ -195,23 +108,19 @@ namespace Inventory_Management_App
         private void MinusButton_Click(object sender, EventArgs e)
         {
             // 数量を1ずつ減らす、最小値は0（負の値にはならない）
-
             if (CurrentAmount > MIN_CURRENT_AMOUNT)
             {
                 CurrentAmount--;
-                textBox1.Text = CurrentAmount.ToString(); // 変換
                 CommaValue();
             }
-
         }
 
         // テキストボックスからフォーカスが外れた時の処理
         private void TextBox1_Leave(object sender, EventArgs e)
         {
             // カンマを除去して数値のみを取得
-            string InputText = textBox1.Text.Replace(",", "");
+            string InputText = CountTextBox.Text.Replace(",", "");
 
-            // 数値に変換できるか確認
             if (int.TryParse(InputText, out int InputAmount))
             {
                 // 0から9999の範囲に制限
@@ -240,13 +149,13 @@ namespace Inventory_Management_App
         private void CommaValue()
         {
             // 3桁区切りのカンマ付きで表示
-            textBox1.Text = CurrentAmount.ToString("N0");
+            CountTextBox.Text = CurrentAmount.ToString("N0");
         }
 
         // タイマー表示
         private void Timer_Tick(object sender, EventArgs e)
         {
-            label2.Text = DateTime.Now.ToString("HH:mm:ss");
+            TimeLabel.Text = DateTime.Now.ToString("HH:mm:ss");
         }
 
         // DataGridの設定
@@ -322,7 +231,7 @@ namespace Inventory_Management_App
             this.Controls.Add(InventoryDataGridView);
         }
 
-        // ListViewのクリックイベント
+        // DataGridView のクリックイベント
         private void InventoryDataGridView_CellContentClick(object sender, DataGridViewCellEventArgs e)
         {
 
@@ -338,42 +247,57 @@ namespace Inventory_Management_App
                 UpdateRowBackgroundColors();
             }
             // 詳細ボタンがクリックされた場合
-            else if(e.ColumnIndex == COLUMN_INDEX_DETAIL)
+            else if (e.ColumnIndex == COLUMN_INDEX_DETAIL)
             {
                 DetailRow(e.RowIndex);
             }
         }
 
-        // 削除メソッドを追加
+        // 削除メソッド（DBからも削除）
         private void DeleteRow(int RowIndex)
         {
-            // 削除確認ダイアログを表示
-            var result = MessageBox.Show("この行を削除しますか？", "確認", MessageBoxButtons.YesNo, MessageBoxIcon.Question);
-            if (result == DialogResult.Yes)
+            DialogResult Result = MessageBox.Show("この行を削除しますか？\n※データベースからも削除されます。","確認", 
+                                    MessageBoxButtons.YesNo, MessageBoxIcon.Question);
+
+            if (Result == DialogResult.Yes)
             {
-                InventoryDataGridView.Rows.RemoveAt(RowIndex);
-                UpdateRowBackgroundColors();
+                DataGridViewRow row = InventoryDataGridView.Rows[RowIndex];
+
+                // Tagの取得を安全に行う　!!!
+                int? ItemId = row.Tag is int id ? id : (int?)null;
+
+                // データベースに保存済みの行の場合は、DBからも削除
+                if (ItemId.HasValue)
+                {
+                    // DB削除処理 !変数名変更!
+                    bool Success = DatabaseHelper.DeleteInventoryItem(ItemId.Value);
+                    if (!Success)
+                    {
+                        // DB削除に失敗したら処理を中止
+                        return;
+                    }
+                }
+
+                InventoryDataGridView.Rows.RemoveAt(RowIndex); // DataGridViewから行を削除
+                UpdateRowBackgroundColors(); // 行の背景色を更新
             }
         }
 
-        // 詳細ボタン（リストビューの現在時刻/数量/コメントが表示）
+        // 詳細ボタン
         private void DetailRow(int RowIndex)
         {
-            // 行データを取得
+            // 行データを取得 ??について
             DataGridViewRow row = InventoryDataGridView.Rows[RowIndex];
             string time = row.Cells[COLUMN_INDEX_TIME].Value?.ToString() ?? "";
-            string quantity = row.Cells[COLUMN_INDEX_QUANTITY].Value?.ToString() ?? ""; 
+            string quantity = row.Cells[COLUMN_INDEX_QUANTITY].Value?.ToString() ?? "";
             string comment = row.Cells[COLUMN_INDEX_COMMENT].Value?.ToString() ?? "";
-            // 詳細メッセージを作成
-            string detailMessage = $"時刻: {time}\n数量: {quantity}\nコメント: {comment}";
-            // メッセージボックスで表示(デバッグ用）
-            //MessageBox.Show(detailMessage, "行の詳細", MessageBoxButtons.OK, MessageBoxIcon.Information);
-            
-            // 画面を切り替えて表示
-            // DetailFormのインスタンスを作成し、データを渡す
-            Form detailForm = new Form2(time, quantity, comment);
-            detailForm.Show();
 
+            // 行のIDを取得（画像表示のため）!!!
+            int? inventoryItemId = row.Tag is int id ? id : (int?)null;
+
+            // 詳細フォームを表示
+            Form detailForm = new DetailForm2(time, quantity, comment, inventoryItemId);
+            detailForm.Show();
         }
 
         // 在庫追加ボタン
@@ -384,14 +308,14 @@ namespace Inventory_Management_App
             // 現在時刻を取得
             string CurrentTime = DateTime.Now.ToString("HH:mm:ss");
             // 数量を取得
-            string Quantity = CurrentAmount.ToString("N0"); // カンマ付き
+            string Quantity = CurrentAmount.ToString("N0");
             // コメントを取得
-            string Comment = textBox2.Text;
+            string Comment = CommentTextBox.Text;
             // 削除を取得
             string Delete = "";
 
             // DataGridViewに新しい行を追加
-            InventoryDataGridView.Rows.Add(CheckBoxValue, CurrentTime, Quantity, Comment, Delete);
+            int RowIndex = InventoryDataGridView.Rows.Add(CheckBoxValue, CurrentTime, Quantity, Comment, Delete);
 
             // 行の背景色を更新
             UpdateRowBackgroundColors();
@@ -402,30 +326,29 @@ namespace Inventory_Management_App
         {
             for (int i = 0; i < InventoryDataGridView.Rows.Count; i++)
             {
+                // 各行を取得
                 DataGridViewRow Row = InventoryDataGridView.Rows[i];
 
-                // チェックボックスの値を取得
-                // 合計計算に含めるかどうかを示すチェックボックスの値を取得
+                // // 合計計算に含めるかどうかを示すチェックボックスの値を取得
                 bool IncludedInTotal = Row.Cells[COLUMN_INDEX_CHECKBOX].Value is bool CheckBoxcellValue && CheckBoxcellValue;
 
                 // 選択済み（合計計算に含まれる行）
                 if (IncludedInTotal)
                 {
-                    Row.DefaultCellStyle.BackColor = Color.LightGreen;  // 緑色
+                    Row.DefaultCellStyle.BackColor = Color.LightGreen; // 緑色
                 }
                 // 偶数行（0, 2, 4...）
                 else if (i % 2 == 0)
                 {
-                    Row.DefaultCellStyle.BackColor = Color.White;  // 白色（背景色なし）
+                    Row.DefaultCellStyle.BackColor = Color.White; // 白色（背景色なし）
                 }
                 // 奇数行（1, 3, 5...）
                 else
                 {
-                    Row.DefaultCellStyle.BackColor = Color.LightBlue;  // 青色
+                    Row.DefaultCellStyle.BackColor = Color.LightBlue; // 青色
                 }
             }
         }
-
 
         // 合計数量ボタンがクリックされたときの処理
         private void TotalQuantity_Click(object sender, EventArgs e)
@@ -435,7 +358,7 @@ namespace Inventory_Management_App
 
             foreach (DataGridViewRow row in InventoryDataGridView.Rows)
             {
-                // この行を合計計算に含めるかどうかを判定
+                // チェックボックスの値を取得
                 bool IncludedInTotal = row.Cells[COLUMN_INDEX_CHECKBOX].Value is bool CheckBoxcellValue && CheckBoxcellValue;
 
                 if (IncludedInTotal)
@@ -450,88 +373,65 @@ namespace Inventory_Management_App
                 }
             }
             // 合計数量をメッセージボックスで表示
-            MessageBox.Show($"選択された合計数量: {TotalOfCheckedRows:N0}", "合計数量", MessageBoxButtons.OK, MessageBoxIcon.Information);
+            MessageBox.Show($"選択された合計数量: {TotalOfCheckedRows:N0}", "合計数量",
+                MessageBoxButtons.OK, MessageBoxIcon.Information);
         }
 
+        // クリアボタンがクリックされたときの処理
         private void ClearButton_Click(object sender, EventArgs e)
         {
             // 削除確認ダイアログを表示
-            var result = MessageBox.Show("データをクリアしますか？", "確認", MessageBoxButtons.YesNo, MessageBoxIcon.Question);
+            DialogResult Result = MessageBox.Show(
+                "すべてのデータをクリアしますか？\n※データベースからも完全に削除されます。",
+                "確認",
+                MessageBoxButtons.YesNo,
+                MessageBoxIcon.Warning);
+
             // 「はい」が選択された場合のみ削除
-            if (result == DialogResult.Yes)
+            if (Result == DialogResult.Yes)
             {
-                // DataGridViewの全行を削除
-                InventoryDataGridView.Rows.Clear();
+                // データベースからも全データを削除 !変数名変更!
+                bool Success = DatabaseHelper.ClearAllInventoryItems();
+
+                // DataGridViewから全データを削除
+                if (Success)
+                {
+                    InventoryDataGridView.Rows.Clear();
+                }
             }
         }
 
-        // 更新ボタン(DBに登録）
+        // 更新ボタンがクリックされたときの処理(DBに登録）
         private void UpdateButton_Click(object sender, EventArgs e)
         {
-            var result = MessageBox.Show("DataGridViewの全データをデータベースに保存しますか？", "保存確認",
-                MessageBoxButtons.YesNo, MessageBoxIcon.Question);
+            DialogResult Result = MessageBox.Show("DataGridViewの全データをデータベースに保存しますか？", "保存確認", 
+                                    MessageBoxButtons.YesNo, MessageBoxIcon.Question);
 
-            if (result == DialogResult.Yes)
+            // 「はい」が選択された場合のみ保存
+            if (Result == DialogResult.Yes)
             {
-                    using (var connection = new SqliteConnection(connectionString))
-                    {
-                        connection.Open();
+                // DataGridViewのデータをDBに保存(挿入・更新)
+                int InsertedCount;
+                int UpdatedCount;
+                // 保存処理 !変数名変更!
+                bool Success = DatabaseHelper.SaveInventoryItems(
+                    InventoryDataGridView,
+                    COLUMN_INDEX_CHECKBOX,
+                    COLUMN_INDEX_TIME,
+                    COLUMN_INDEX_QUANTITY,
+                    COLUMN_INDEX_COMMENT,
+                    out InsertedCount,
+                    out UpdatedCount
+                );
 
-                        // トランザクション開始
-                        using (var transaction = connection.BeginTransaction())
-                        {
-                                // 既存データを全削除
-                                string deleteQuery = "DELETE FROM InventoryItems";
-                                using (var deleteCommand = new SqliteCommand(deleteQuery, connection, transaction))
-                                {
-                                    deleteCommand.ExecuteNonQuery();
-                                }
-
-                                // DataGridViewの全データを挿入
-                                string insertQuery = @"
-                                    INSERT INTO InventoryItems (IsChecked, Time, Quantity, Comment)
-                                    VALUES (@IsChecked, @Time, @Quantity, @Comment)";
-
-                                int savedCount = 0;
-
-                                foreach (DataGridViewRow row in InventoryDataGridView.Rows)
-                                {
-                                    // チェックボックスの値を取得
-                                    bool isChecked = row.Cells[COLUMN_INDEX_CHECKBOX].Value is bool checkValue && checkValue;
-
-                                    // 時刻を取得
-                                    string time = row.Cells[COLUMN_INDEX_TIME].Value?.ToString() ?? DateTime.Now.ToString("HH:mm:ss");
-
-                                    // 数量を取得（カンマを除去して数値に変換）
-                                    string quantityText = row.Cells[COLUMN_INDEX_QUANTITY].Value?.ToString()?.Replace(",", "") ?? "0";
-                                    int quantity = int.TryParse(quantityText, out int qty) ? qty : 0;
-
-                                    // コメントを取得
-                                    string comment = row.Cells[COLUMN_INDEX_COMMENT].Value?.ToString() ?? "";
-
-                                    // データベースに挿入
-                                    using (var insertCommand = new SqliteCommand(insertQuery, connection, transaction))
-                                    {
-                                        insertCommand.Parameters.AddWithValue("@IsChecked", isChecked ? 1 : 0);
-                                        insertCommand.Parameters.AddWithValue("@Time", time);
-                                        insertCommand.Parameters.AddWithValue("@Quantity", quantity);
-                                        insertCommand.Parameters.AddWithValue("@Comment", comment);
-
-                                        insertCommand.ExecuteNonQuery();
-                                        savedCount++;
-                                    }
-                                }
-
-                                // コミット
-                                transaction.Commit();
-
-                                // データを再読み込み
-                                LoadDataFromDatabase();
-
-                                MessageBox.Show($"データベースに{savedCount}件のデータを保存しました。", "保存完了",
-                                    MessageBoxButtons.OK, MessageBoxIcon.Information);
-                        }
-                    }
+                // 保存成功時の処理
+                if (Success)
+                {
+                    // 保存後、DBの最新データでリロードする（Tagもここでセットされる）
+                    LoadDataFromDatabase();
+                    MessageBox.Show($"保存完了", "保存完了",
+                        MessageBoxButtons.OK, MessageBoxIcon.Information);
+                }
             }
         }
     }

--- a/Inventory Management App/Form1.cs
+++ b/Inventory Management App/Form1.cs
@@ -32,8 +32,6 @@ namespace Inventory_Management_App
         private int CurrentAmount = DEFAULT_CURRENT_AMOUNT;
 
         // 時刻
-        //private DispatcherTimer timer;
-        // ↓修正案
         private System.Windows.Forms.Timer timer; // WinForms用タイマー
 
         // 在庫リスト表示用DataGridView
@@ -46,18 +44,6 @@ namespace Inventory_Management_App
             // 初期値を設定,数値→文字形式に変換
             CountTextBox.Text = DEFAULT_CURRENT_AMOUNT.ToString();
 
-            // タイマのインスタンスを生成
-            //timer = new DispatcherTimer();
-            //// 1秒ごとにイベントを発生させます。
-            //timer.Interval = TimeSpan.FromSeconds(1);
-            //// タイマーのTickイベントにTimer_Tickメソッドを関連付け
-            //// timer.Tick:イベント
-            //// Timer_Tick:メソッド
-            //timer.Tick += Timer_Tick;
-            //// timerをスタートさせます。
-            //timer.Start();
-
-            //↓修正案(問題なければ、こちらを採用。上記は削除する予定）
             //タイマーのインスタンスを生成（WinForms.Timerを使用）
             timer = new System.Windows.Forms.Timer();
              timer.Interval = 1000; // 1秒（ミリ秒）

--- a/Inventory Management App/Form1.cs
+++ b/Inventory Management App/Form1.cs
@@ -399,6 +399,8 @@ namespace Inventory_Management_App
                 // DataGridViewのデータをDBに保存(挿入・更新)
                 int InsertedCount;
                 int UpdatedCount;
+                List<int> NewInsertedIds; // 追加: 新規挿入されたIDリスト
+
                 // 保存処理 !変数名変更!
                 bool Success = DatabaseHelper.SaveInventoryItems(
                     InventoryDataGridView,
@@ -407,16 +409,31 @@ namespace Inventory_Management_App
                     COLUMN_INDEX_QUANTITY,
                     COLUMN_INDEX_COMMENT,
                     out InsertedCount,
-                    out UpdatedCount
+                    out UpdatedCount,
+                    out NewInsertedIds // 追加: 新規挿入されたIDリスト
                 );
 
                 // 保存成功時の処理
                 if (Success)
                 {
-                    // 保存後、DBの最新データでリロードする（Tagもここでセットされる）
-                    LoadDataFromDatabase();
-                    MessageBox.Show($"保存完了", "保存完了",
-                        MessageBoxButtons.OK, MessageBoxIcon.Information);
+                    // 新規挿入された行に Tag を設定
+                    int newIdIndex = 0;
+                    for (int i = 0; i < InventoryDataGridView.Rows.Count; i++)
+                    {
+                        DataGridViewRow row = InventoryDataGridView.Rows[i];
+
+                        if (!(row.Tag is int))  // Tagが未設定 = 新規挿入行
+                        {
+                            if (newIdIndex < NewInsertedIds.Count)
+                            {
+                                row.Tag = NewInsertedIds[newIdIndex];  // IDを設定
+                                newIdIndex++;
+                            }
+                        }
+                    }
+                    // 背景色を更新
+                    UpdateRowBackgroundColors();
+
                 }
             }
         }

--- a/Inventory Management App/Form2.Designer.cs
+++ b/Inventory Management App/Form2.Designer.cs
@@ -22,7 +22,7 @@ namespace Inventory_Management_App
             }
             base.Dispose(disposing);
         }
-        
+
 
         #region Windows Form Designer generated code
 

--- a/Inventory Management App/Form2.Designer.cs
+++ b/Inventory Management App/Form2.Designer.cs
@@ -1,0 +1,124 @@
+﻿using System.Xml.Linq;
+using static System.Windows.Forms.VisualStyles.VisualStyleElement.TaskbarClock;
+
+namespace Inventory_Management_App
+{
+    partial class Form2
+    {
+        /// <summary>
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary>
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+        
+
+        #region Windows Form Designer generated code
+
+        /// <summary>
+        /// Required method for Designer support - do not modify
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent() //string time, string quantity, string comment
+        {
+            this.InsertImagebutton = new System.Windows.Forms.Button();
+            this.label1 = new System.Windows.Forms.Label();
+            this.label2 = new System.Windows.Forms.Label();
+            this.label3 = new System.Windows.Forms.Label();
+            this.Deletebutton = new System.Windows.Forms.Button();
+            this.SaveButton = new System.Windows.Forms.Button();
+            this.SuspendLayout();
+            // 
+            // InsertImagebutton
+            // 
+            this.InsertImagebutton.Location = new System.Drawing.Point(12, 101);
+            this.InsertImagebutton.Name = "InsertImagebutton";
+            this.InsertImagebutton.Size = new System.Drawing.Size(100, 25);
+            this.InsertImagebutton.TabIndex = 0;
+            this.InsertImagebutton.Text = "画像を挿入";
+            this.InsertImagebutton.UseVisualStyleBackColor = true;
+            this.InsertImagebutton.Click += new System.EventHandler(this.InsertImageButton_Click);
+            // 
+            // label1
+            // 
+            this.label1.AutoSize = true;
+            this.label1.Location = new System.Drawing.Point(10, 10);
+            this.label1.Name = "label1";
+            this.label1.Size = new System.Drawing.Size(0, 15);
+            this.label1.TabIndex = 1;
+            // 
+            // label2
+            // 
+            this.label2.AutoSize = true;
+            this.label2.Location = new System.Drawing.Point(12, 25);
+            this.label2.Name = "label2";
+            this.label2.Size = new System.Drawing.Size(0, 15);
+            this.label2.TabIndex = 2;
+            // 
+            // label3
+            // 
+            this.label3.AutoSize = true;
+            this.label3.Location = new System.Drawing.Point(12, 40);
+            this.label3.Name = "label3";
+            this.label3.Size = new System.Drawing.Size(0, 15);
+            this.label3.TabIndex = 3;
+            // 
+            // Deletebutton
+            // 
+            this.Deletebutton.Location = new System.Drawing.Point(15, 156);
+            this.Deletebutton.Name = "Deletebutton";
+            this.Deletebutton.Size = new System.Drawing.Size(97, 25);
+            this.Deletebutton.TabIndex = 4;
+            this.Deletebutton.Text = "画像を削除";
+            this.Deletebutton.UseVisualStyleBackColor = true;
+            this.Deletebutton.Click += new System.EventHandler(this.DeleteButton_Click);
+            // 
+            // SaveButton
+            // 
+            this.SaveButton.Location = new System.Drawing.Point(15, 210);
+            this.SaveButton.Name = "SaveButton";
+            this.SaveButton.Size = new System.Drawing.Size(97, 25);
+            this.SaveButton.TabIndex = 5;
+            this.SaveButton.Text = "画像を保存";
+            this.SaveButton.UseVisualStyleBackColor = true;
+            this.SaveButton.Click += new System.EventHandler(this.SaveButton_Click);
+            // 
+            // Form2
+            // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 15F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.ClientSize = new System.Drawing.Size(800, 450);
+            this.Controls.Add(this.SaveButton);
+            this.Controls.Add(this.Deletebutton);
+            this.Controls.Add(this.label3);
+            this.Controls.Add(this.label2);
+            this.Controls.Add(this.label1);
+            this.Controls.Add(this.InsertImagebutton);
+            this.Name = "Form2";
+            this.Text = "Form2";
+            this.ResumeLayout(false);
+            this.PerformLayout();
+
+        }
+
+        #endregion
+        // endregion
+        private System.Windows.Forms.Button InsertImagebutton;
+        private System.Windows.Forms.Label label1;
+        private System.Windows.Forms.Label label2;
+        private System.Windows.Forms.Label label3;
+        private System.Windows.Forms.Button Deletebutton;
+        private System.Windows.Forms.Button SaveButton;
+    }
+}

--- a/Inventory Management App/Form2.Designer.cs
+++ b/Inventory Management App/Form2.Designer.cs
@@ -3,7 +3,7 @@ using static System.Windows.Forms.VisualStyles.VisualStyleElement.TaskbarClock;
 
 namespace Inventory_Management_App
 {
-    partial class Form2
+    partial class DetailForm2
     {
         /// <summary>
         /// Required designer variable.
@@ -33,16 +33,16 @@ namespace Inventory_Management_App
         private void InitializeComponent() //string time, string quantity, string comment
         {
             this.InsertImagebutton = new System.Windows.Forms.Button();
-            this.label1 = new System.Windows.Forms.Label();
-            this.label2 = new System.Windows.Forms.Label();
-            this.label3 = new System.Windows.Forms.Label();
+            this.TimeLabel = new System.Windows.Forms.Label();
+            this.QuantityLavel = new System.Windows.Forms.Label();
+            this.CommentLavel = new System.Windows.Forms.Label();
             this.Deletebutton = new System.Windows.Forms.Button();
             this.SaveButton = new System.Windows.Forms.Button();
             this.SuspendLayout();
             // 
             // InsertImagebutton
             // 
-            this.InsertImagebutton.Location = new System.Drawing.Point(12, 101);
+            this.InsertImagebutton.Location = new System.Drawing.Point(195, 25);
             this.InsertImagebutton.Name = "InsertImagebutton";
             this.InsertImagebutton.Size = new System.Drawing.Size(100, 25);
             this.InsertImagebutton.TabIndex = 0;
@@ -50,33 +50,33 @@ namespace Inventory_Management_App
             this.InsertImagebutton.UseVisualStyleBackColor = true;
             this.InsertImagebutton.Click += new System.EventHandler(this.InsertImageButton_Click);
             // 
-            // label1
+            // TimeLabel
             // 
-            this.label1.AutoSize = true;
-            this.label1.Location = new System.Drawing.Point(10, 10);
-            this.label1.Name = "label1";
-            this.label1.Size = new System.Drawing.Size(0, 15);
-            this.label1.TabIndex = 1;
+            this.TimeLabel.AutoSize = true;
+            this.TimeLabel.Location = new System.Drawing.Point(10, 10);
+            this.TimeLabel.Name = "TimeLabel";
+            this.TimeLabel.Size = new System.Drawing.Size(0, 15);
+            this.TimeLabel.TabIndex = 1;
             // 
-            // label2
+            // QuantityLavel
             // 
-            this.label2.AutoSize = true;
-            this.label2.Location = new System.Drawing.Point(12, 25);
-            this.label2.Name = "label2";
-            this.label2.Size = new System.Drawing.Size(0, 15);
-            this.label2.TabIndex = 2;
+            this.QuantityLavel.AutoSize = true;
+            this.QuantityLavel.Location = new System.Drawing.Point(12, 25);
+            this.QuantityLavel.Name = "QuantityLavel";
+            this.QuantityLavel.Size = new System.Drawing.Size(0, 15);
+            this.QuantityLavel.TabIndex = 2;
             // 
-            // label3
+            // CommentLavel
             // 
-            this.label3.AutoSize = true;
-            this.label3.Location = new System.Drawing.Point(12, 40);
-            this.label3.Name = "label3";
-            this.label3.Size = new System.Drawing.Size(0, 15);
-            this.label3.TabIndex = 3;
+            this.CommentLavel.AutoSize = true;
+            this.CommentLavel.Location = new System.Drawing.Point(12, 40);
+            this.CommentLavel.Name = "CommentLavel";
+            this.CommentLavel.Size = new System.Drawing.Size(0, 15);
+            this.CommentLavel.TabIndex = 3;
             // 
             // Deletebutton
             // 
-            this.Deletebutton.Location = new System.Drawing.Point(15, 156);
+            this.Deletebutton.Location = new System.Drawing.Point(344, 25);
             this.Deletebutton.Name = "Deletebutton";
             this.Deletebutton.Size = new System.Drawing.Size(97, 25);
             this.Deletebutton.TabIndex = 4;
@@ -86,7 +86,7 @@ namespace Inventory_Management_App
             // 
             // SaveButton
             // 
-            this.SaveButton.Location = new System.Drawing.Point(15, 210);
+            this.SaveButton.Location = new System.Drawing.Point(497, 25);
             this.SaveButton.Name = "SaveButton";
             this.SaveButton.Size = new System.Drawing.Size(97, 25);
             this.SaveButton.TabIndex = 5;
@@ -94,19 +94,19 @@ namespace Inventory_Management_App
             this.SaveButton.UseVisualStyleBackColor = true;
             this.SaveButton.Click += new System.EventHandler(this.SaveButton_Click);
             // 
-            // Form2
+            // DetailForm2
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 15F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.ClientSize = new System.Drawing.Size(800, 450);
             this.Controls.Add(this.SaveButton);
             this.Controls.Add(this.Deletebutton);
-            this.Controls.Add(this.label3);
-            this.Controls.Add(this.label2);
-            this.Controls.Add(this.label1);
+            this.Controls.Add(this.CommentLavel);
+            this.Controls.Add(this.QuantityLavel);
+            this.Controls.Add(this.TimeLabel);
             this.Controls.Add(this.InsertImagebutton);
-            this.Name = "Form2";
-            this.Text = "Form2";
+            this.Name = "DetailForm2";
+            this.Text = "DetailForm2";
             this.ResumeLayout(false);
             this.PerformLayout();
 
@@ -115,9 +115,9 @@ namespace Inventory_Management_App
         #endregion
         // endregion
         private System.Windows.Forms.Button InsertImagebutton;
-        private System.Windows.Forms.Label label1;
-        private System.Windows.Forms.Label label2;
-        private System.Windows.Forms.Label label3;
+        private System.Windows.Forms.Label TimeLabel;
+        private System.Windows.Forms.Label QuantityLavel;
+        private System.Windows.Forms.Label CommentLavel;
         private System.Windows.Forms.Button Deletebutton;
         private System.Windows.Forms.Button SaveButton;
     }

--- a/Inventory Management App/Form2.cs
+++ b/Inventory Management App/Form2.cs
@@ -1,67 +1,99 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.ComponentModel;
-using System.Data;
 using System.Drawing;
 using System.IO;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using System.Windows.Forms;
-using System.Xml.Linq;
-using static System.Windows.Forms.VisualStyles.VisualStyleElement.TaskbarClock;
 
 namespace Inventory_Management_App
 {
-    public partial class Form2 : Form
+    // 詳細情報フォーム
+    public partial class DetailForm2 : Form
     {
         // 画像を管理（現在は1枚のみ）
-        private PictureBox currentPictureBox = null;
+        private PictureBox CurrentPictureBox = null;
 
         // パネルを使用してスクロール可能にする
-        private Panel imagePanel;
+        private Panel ImagePanel;
 
-        //Form1から渡されたデータを受け取るコンストラクタ
-        public Form2(string time, string quantity, string comment)
+        // 画像サイズ制限（2MB）
+        private const int MaxImageSizeBytes = 2 * 1024 * 1024;
+
+        // InventoryItemのID（画像の関連付けに使用）!!!
+        private int? InventoryItemId;
+
+        // Form1から渡されたデータを受け取るコンストラクタ
+        public DetailForm2(string time, string quantity, string comment, int? itemId = null)
         {
-            // 画像表示用パネルの初期化
+            // コンポーネントの初期化
             InitializeComponent();
 
             // タイトルの設定
             this.Text = "詳細情報";
 
             // 渡されたデータをラベルに表示
-            label1.Text = $"時刻: {time}";
-            label2.Text = $"数量: {quantity}";
-            label3.Text = $"コメント: {comment}";
+            TimeLabel.Text = $"時刻: {time}";
+            QuantityLavel.Text = $"数量: {quantity}";
+            CommentLavel.Text = $"コメント: {comment}";
+
+            // InventoryItemIdを保存
+            InventoryItemId = itemId;
 
             // 画像表示用パネルの初期化
             InitializeImagePanel();
+
+            // データベースから画像を読み込む
+            LoadImageFromDatabase();
         }
 
         // 画像表示用パネルの初期化
         private void InitializeImagePanel()
         {
-            //
-            imagePanel = new Panel();
-            imagePanel.Location = new Point(140, 20);
-            imagePanel.Size = new Size(760, 280);
-            imagePanel.AutoScroll = false; // スクロール不要（1枚のみ）
-            imagePanel.BorderStyle = BorderStyle.FixedSingle;
-            this.Controls.Add(imagePanel);
+            ImagePanel = new Panel();
+            ImagePanel.Location = new Point(20, 80);
+            ImagePanel.Size = new Size(520, 280);
+            ImagePanel.AutoScroll = true; // スクロールを有効にする
+            ImagePanel.BorderStyle = BorderStyle.FixedSingle; // 枠線を追加
+            this.Controls.Add(ImagePanel); // フォームにパネルを追加
         }
-        // 画像を挿入するボタンを作成
+
+        // データベースから画像を読み込む（行IDに紐づく画像のみ）
+        private void LoadImageFromDatabase()
+        {
+            // InventoryItemIdがない場合は画像を読み込まない
+            if (!InventoryItemId.HasValue)
+            {
+                return; // 中止
+            }
+
+            try
+            {
+                // 共通メソッドを使用して画像を取得
+                var images = DatabaseHelper.LoadImagesForInventoryItem(InventoryItemId.Value);
+                if (images.Count > 0)
+                {
+                    AddImageToPanelFromImage(images[0]); // 最初の画像を表示
+                }
+            }
+            catch (Exception ex)
+            {
+                MessageBox.Show($"画像の読み込みに失敗しました: {ex.Message}", "エラー",
+                    MessageBoxButtons.OK, MessageBoxIcon.Error);
+            }
+        }
+
+        // 画像を挿入するボタンのイベント
         private void InsertImageButton_Click(object sender, EventArgs e)
         {
             // 既に画像がある場合は警告
-            if (currentPictureBox != null)
+            if (CurrentPictureBox != null)
             {
-                var result = MessageBox.Show("既に画像が挿入されています。新しい画像に置き換えますか？",
-                    "確認", MessageBoxButtons.YesNo, MessageBoxIcon.Question);
+                DialogResult confirmResult = MessageBox.Show("既に画像が挿入されています。新しい画像に置き換えますか？","確認", 
+                    MessageBoxButtons.YesNo, MessageBoxIcon.Question);
 
-                if (result == DialogResult.No)
+                // ユーザーが「いいえ」を選択した場合は処理を中止
+                if (confirmResult != DialogResult.Yes)
                 {
-                    return;
+                    return; // 中止
                 }
 
                 // 既存の画像を削除
@@ -71,41 +103,56 @@ namespace Inventory_Management_App
             // OpenFileDialogを使用して画像ファイルを選択
             using (OpenFileDialog openFileDialog = new OpenFileDialog())
             {
-                openFileDialog.Title = "画像を選択";
-                openFileDialog.Filter = "画像ファイル (*.jpg;*.jpeg;*.png;*.bmp)|*.jpg;*.jpeg;*.png;*.bmp";
-                openFileDialog.Multiselect = false; // 1枚のみ選択
+                // ダイアログの設定
+                openFileDialog.Title = "画像を選択"; 
+                openFileDialog.Filter = "画像ファイル (*.jpg;*.jpeg;*.png;)|*.jpg;*.jpeg;*.png;";
+                openFileDialog.Multiselect = false; // 複数選択不可
+
+                // ダイアログを表示
                 if (openFileDialog.ShowDialog() == DialogResult.OK)
                 {
-                    foreach (string imagePath in openFileDialog.FileNames)
+                    // ファイルサイズチェック(2MBまで)
+                    FileInfo fileInfo = new FileInfo(openFileDialog.FileName);
+
+                    // サイズが制限を超えている場合は警告
+                    if (fileInfo.Length > MaxImageSizeBytes)
                     {
-                        AddImageToPanel(imagePath);
+                        MessageBox.Show($"画像ファイルのサイズが2MBを超えています。\n現在のサイズ: {fileInfo.Length / 1024.0 / 1024.0:F2}MB","エラー", 
+                            MessageBoxButtons.OK, MessageBoxIcon.Error);
+                        return;
                     }
+
+                    // 画像ファイルをImageとして読み込む
+                    Image image = Image.FromFile(openFileDialog.FileName);
+                    // パネルに画像を追加
+                    AddImageToPanelFromImage(image);
                 }
             }
         }
 
-        // パネルに画像を追加
-        private void AddImageToPanel(string imagePath)
+        // パネルにImageオブジェクトから画像を追加するメソッド
+        private void AddImageToPanelFromImage(Image image)
         {
             try
             {
-                // ピクチャーボックスを作成
-                PictureBox pictureBox = new PictureBox();
+                // PictureBoxを作成して画像を表示
+                PictureBox pictureBox = new PictureBox(); // 新しいPictureBoxを作成
+                pictureBox.SizeMode = PictureBoxSizeMode.Zoom; // サイズに合わせて拡大縮小
+                pictureBox.Location = new Point(100,20); // 
+                pictureBox.Size = new Size(Math.Min(ImagePanel.Width, image.Width), Math.Min(ImagePanel.Height, image.Height)); // パネル内に収まるサイズに調整
+                pictureBox.Anchor = AnchorStyles.Top | AnchorStyles.Left; // 左上に固定
+                pictureBox.Image = new Bitmap(image); // 画像を設定
 
-                // 画像を読み込む
-                Image originalImage = Image.FromFile(imagePath);
-
+                // 既存の画像があれば削除
+                RemoveCurrentImage();
 
                 // 現在の画像として保存
-                currentPictureBox = pictureBox;
-
-                // パネルに追加
-                imagePanel.Controls.Add(pictureBox);
-                pictureBox.Image = originalImage;
+                CurrentPictureBox = pictureBox;
+                ImagePanel.Controls.Add(pictureBox);
             }
             catch (Exception ex)
             {
-                MessageBox.Show($"画像の読み込みに失敗しました: {ex.Message}", "エラー",
+                MessageBox.Show($"画像の表示に失敗しました: {ex.Message}", "エラー", 
                     MessageBoxButtons.OK, MessageBoxIcon.Error);
             }
         }
@@ -113,37 +160,84 @@ namespace Inventory_Management_App
         // 現在の画像を削除
         private void RemoveCurrentImage()
         {
-            if (currentPictureBox != null)
+            // 既存のPictureBoxがあれば削除
+            if (CurrentPictureBox != null)
             {
-                imagePanel.Controls.Remove(currentPictureBox);
-                currentPictureBox.Dispose();
-                currentPictureBox = null;
+                // パネルから削除してリソースを解放
+                ImagePanel.Controls.Remove(CurrentPictureBox); // パネルから削除
+                CurrentPictureBox.Image?.Dispose(); // 画像リソースを解放
+                CurrentPictureBox.Dispose(); // PictureBox自体を解放
+                CurrentPictureBox = null; // 参照をクリア
             }
         }
-
 
         // 画像を削除するボタンのイベント
         private void DeleteButton_Click(object sender, EventArgs e)
         {
-            if (currentPictureBox == null)
+            // 画像がない場合は警告
+            if (CurrentPictureBox == null)
             {
-                MessageBox.Show("削除する画像がありません。", "情報",
+                MessageBox.Show("削除する画像がありません。", "情報", 
                     MessageBoxButtons.OK, MessageBoxIcon.Information);
                 return;
             }
 
-            var result = MessageBox.Show("画像を削除しますか?", "確認",
+            DialogResult Result = MessageBox.Show("画像を削除しますか?", "確認", 
                 MessageBoxButtons.YesNo, MessageBoxIcon.Question);
 
-            if (result == DialogResult.Yes)
+            // ユーザーが「はい」を選択した場合に削除
+            if (Result == DialogResult.Yes)
             {
-                RemoveCurrentImage();
+                RemoveCurrentImage(); // 画像を削除
             }
         }
 
-        // 画像を保存するボタンのイベント
+        // 画像を保存するボタンのイベント（共通メソッドを使用）
         private void SaveButton_Click(object sender, EventArgs e)
         {
+            // 画像がない場合は警告
+            if (CurrentPictureBox == null)
+            {
+                MessageBox.Show("保存する画像がありません。", "情報",
+                    MessageBoxButtons.OK, MessageBoxIcon.Information);
+                return;
+            }
+
+            // InventoryItemIdがない場合は警告
+            if (!InventoryItemId.HasValue)
+            {
+                MessageBox.Show("この行はまだデータベースに保存されていません。\nForm1の「更新」ボタンで保存してから、画像を登録してください。",
+                    "情報", MessageBoxButtons.OK, MessageBoxIcon.Information);
+                return;
+            }
+
+            try
+            {
+                // 画像をバイト配列に変換
+                byte[] imageData;
+
+                using (var ms = new MemoryStream())
+                {
+                    // PNG形式で保存
+                    CurrentPictureBox.Image.Save(ms, System.Drawing.Imaging.ImageFormat.Png);
+                    imageData = ms.ToArray();
+                }
+
+                // 共通メソッドを使用して保存 !変数名変更予定!
+                bool Success = DatabaseHelper.SaveImage(imageData, InventoryItemId);
+
+                if (Success)
+                {
+                    // 保存成功メッセージ
+                    MessageBox.Show("画像が正常に保存されました。", "情報",
+                        MessageBoxButtons.OK, MessageBoxIcon.Information);
+                }
+            }
+            catch (Exception ex)
+            {
+                MessageBox.Show($"画像の保存に失敗しました: {ex.Message}", "エラー",
+                    MessageBoxButtons.OK, MessageBoxIcon.Error);
+            }
         }
     }
 }

--- a/Inventory Management App/Form2.cs
+++ b/Inventory Management App/Form2.cs
@@ -16,7 +16,17 @@ namespace Inventory_Management_App
         private Panel ImagePanel;
 
         // 画像サイズ制限（2MB）
-        private const int MaxImageSizeBytes = 2 * 1024 * 1024;
+        private const int MAX_IMAGES_SIZE_BYTES = 2 * 1024 * 1024;
+
+        // ImagePanelの位置・サイズ
+        private const int IMAGE_PANEL_X = 20;
+        private const int IMAGE_PANEL_Y = 80;
+        private const int IMAGE_PANEL_WIDTH = 520;
+        private const int IMAGE_PANEL_HEIGHT = 280;
+
+        // PictureBoxの位置
+        private const int PictureBoxX = 100;
+        private const int PictureBoxY = 20;
 
         // InventoryItemのID（画像の関連付けに使用）!!!
         private int? InventoryItemId;
@@ -49,8 +59,8 @@ namespace Inventory_Management_App
         private void InitializeImagePanel()
         {
             ImagePanel = new Panel();
-            ImagePanel.Location = new Point(20, 80);
-            ImagePanel.Size = new Size(520, 280);
+            ImagePanel.Location = new Point(IMAGE_PANEL_X, IMAGE_PANEL_Y);
+            ImagePanel.Size = new Size(IMAGE_PANEL_WIDTH, IMAGE_PANEL_HEIGHT);
             ImagePanel.AutoScroll = true; // スクロールを有効にする
             ImagePanel.BorderStyle = BorderStyle.FixedSingle; // 枠線を追加
             this.Controls.Add(ImagePanel); // フォームにパネルを追加
@@ -115,7 +125,7 @@ namespace Inventory_Management_App
                     FileInfo fileInfo = new FileInfo(openFileDialog.FileName);
 
                     // サイズが制限を超えている場合は警告
-                    if (fileInfo.Length > MaxImageSizeBytes)
+                    if (fileInfo.Length > MAX_IMAGES_SIZE_BYTES)
                     {
                         MessageBox.Show($"画像ファイルのサイズが2MBを超えています。\n現在のサイズ: {fileInfo.Length / 1024.0 / 1024.0:F2}MB","エラー", 
                             MessageBoxButtons.OK, MessageBoxIcon.Error);
@@ -138,7 +148,7 @@ namespace Inventory_Management_App
                 // PictureBoxを作成して画像を表示
                 PictureBox pictureBox = new PictureBox(); // 新しいPictureBoxを作成
                 pictureBox.SizeMode = PictureBoxSizeMode.Zoom; // サイズに合わせて拡大縮小
-                pictureBox.Location = new Point(100,20); // 
+                pictureBox.Location = new Point(PictureBoxX, PictureBoxY); // 定数を使用
                 pictureBox.Size = new Size(Math.Min(ImagePanel.Width, image.Width), Math.Min(ImagePanel.Height, image.Height)); // パネル内に収まるサイズに調整
                 pictureBox.Anchor = AnchorStyles.Top | AnchorStyles.Left; // 左上に固定
                 pictureBox.Image = new Bitmap(image); // 画像を設定
@@ -215,8 +225,8 @@ namespace Inventory_Management_App
             {
                 // 画像をバイト配列に変換
                 byte[] imageData;
-
-                using (var ms = new MemoryStream())
+                // MemoryStreamを使用して画像をバイト配列に変換
+                using (MemoryStream ms = new MemoryStream())
                 {
                     // PNG形式で保存
                     CurrentPictureBox.Image.Save(ms, System.Drawing.Imaging.ImageFormat.Png);
@@ -224,9 +234,9 @@ namespace Inventory_Management_App
                 }
 
                 // 共通メソッドを使用して保存 !変数名変更予定!
-                bool Success = DatabaseHelper.SaveImage(imageData, InventoryItemId);
+                bool ImageSaveResult = DatabaseHelper.SaveImage(imageData, InventoryItemId);
 
-                if (Success)
+                if (ImageSaveResult)
                 {
                     // 保存成功メッセージ
                     MessageBox.Show("画像が正常に保存されました。", "情報",

--- a/Inventory Management App/Form2.cs
+++ b/Inventory Management App/Form2.cs
@@ -1,0 +1,149 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Data;
+using System.Drawing;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows.Forms;
+using System.Xml.Linq;
+using static System.Windows.Forms.VisualStyles.VisualStyleElement.TaskbarClock;
+
+namespace Inventory_Management_App
+{
+    public partial class Form2 : Form
+    {
+        // 画像を管理（現在は1枚のみ）
+        private PictureBox currentPictureBox = null;
+
+        // パネルを使用してスクロール可能にする
+        private Panel imagePanel;
+
+        //Form1から渡されたデータを受け取るコンストラクタ
+        public Form2(string time, string quantity, string comment)
+        {
+            // 画像表示用パネルの初期化
+            InitializeComponent();
+
+            // タイトルの設定
+            this.Text = "詳細情報";
+
+            // 渡されたデータをラベルに表示
+            label1.Text = $"時刻: {time}";
+            label2.Text = $"数量: {quantity}";
+            label3.Text = $"コメント: {comment}";
+
+            // 画像表示用パネルの初期化
+            InitializeImagePanel();
+        }
+
+        // 画像表示用パネルの初期化
+        private void InitializeImagePanel()
+        {
+            //
+            imagePanel = new Panel();
+            imagePanel.Location = new Point(140, 20);
+            imagePanel.Size = new Size(760, 280);
+            imagePanel.AutoScroll = false; // スクロール不要（1枚のみ）
+            imagePanel.BorderStyle = BorderStyle.FixedSingle;
+            this.Controls.Add(imagePanel);
+        }
+        // 画像を挿入するボタンを作成
+        private void InsertImageButton_Click(object sender, EventArgs e)
+        {
+            // 既に画像がある場合は警告
+            if (currentPictureBox != null)
+            {
+                var result = MessageBox.Show("既に画像が挿入されています。新しい画像に置き換えますか？",
+                    "確認", MessageBoxButtons.YesNo, MessageBoxIcon.Question);
+
+                if (result == DialogResult.No)
+                {
+                    return;
+                }
+
+                // 既存の画像を削除
+                RemoveCurrentImage();
+            }
+
+            // OpenFileDialogを使用して画像ファイルを選択
+            using (OpenFileDialog openFileDialog = new OpenFileDialog())
+            {
+                openFileDialog.Title = "画像を選択";
+                openFileDialog.Filter = "画像ファイル (*.jpg;*.jpeg;*.png;*.bmp)|*.jpg;*.jpeg;*.png;*.bmp";
+                openFileDialog.Multiselect = false; // 1枚のみ選択
+                if (openFileDialog.ShowDialog() == DialogResult.OK)
+                {
+                    foreach (string imagePath in openFileDialog.FileNames)
+                    {
+                        AddImageToPanel(imagePath);
+                    }
+                }
+            }
+        }
+
+        // パネルに画像を追加
+        private void AddImageToPanel(string imagePath)
+        {
+            try
+            {
+                // ピクチャーボックスを作成
+                PictureBox pictureBox = new PictureBox();
+
+                // 画像を読み込む
+                Image originalImage = Image.FromFile(imagePath);
+
+
+                // 現在の画像として保存
+                currentPictureBox = pictureBox;
+
+                // パネルに追加
+                imagePanel.Controls.Add(pictureBox);
+                pictureBox.Image = originalImage;
+            }
+            catch (Exception ex)
+            {
+                MessageBox.Show($"画像の読み込みに失敗しました: {ex.Message}", "エラー",
+                    MessageBoxButtons.OK, MessageBoxIcon.Error);
+            }
+        }
+
+        // 現在の画像を削除
+        private void RemoveCurrentImage()
+        {
+            if (currentPictureBox != null)
+            {
+                imagePanel.Controls.Remove(currentPictureBox);
+                currentPictureBox.Dispose();
+                currentPictureBox = null;
+            }
+        }
+
+
+        // 画像を削除するボタンのイベント
+        private void DeleteButton_Click(object sender, EventArgs e)
+        {
+            if (currentPictureBox == null)
+            {
+                MessageBox.Show("削除する画像がありません。", "情報",
+                    MessageBoxButtons.OK, MessageBoxIcon.Information);
+                return;
+            }
+
+            var result = MessageBox.Show("画像を削除しますか?", "確認",
+                MessageBoxButtons.YesNo, MessageBoxIcon.Question);
+
+            if (result == DialogResult.Yes)
+            {
+                RemoveCurrentImage();
+            }
+        }
+
+        // 画像を保存するボタンのイベント
+        private void SaveButton_Click(object sender, EventArgs e)
+        {
+        }
+    }
+}

--- a/Inventory Management App/Form2.resx
+++ b/Inventory Management App/Form2.resx
@@ -1,0 +1,120 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+</root>

--- a/Inventory Management App/Inventory Management App.csproj
+++ b/Inventory Management App/Inventory Management App.csproj
@@ -104,10 +104,19 @@
     <Compile Include="Form1.Designer.cs">
       <DependentUpon>Form1.cs</DependentUpon>
     </Compile>
+    <Compile Include="Form2.cs">
+      <SubType>Form</SubType>
+    </Compile>
+    <Compile Include="Form2.Designer.cs">
+      <DependentUpon>Form2.cs</DependentUpon>
+    </Compile>
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <EmbeddedResource Include="Form1.resx">
       <DependentUpon>Form1.cs</DependentUpon>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Form2.resx">
+      <DependentUpon>Form2.cs</DependentUpon>
     </EmbeddedResource>
     <EmbeddedResource Include="Properties\Resources.resx">
       <Generator>ResXFileCodeGenerator</Generator>

--- a/Inventory Management App/Inventory Management App.csproj
+++ b/Inventory Management App/Inventory Management App.csproj
@@ -98,6 +98,7 @@
     <Reference Include="WindowsBase" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="CommonDatabaseOperations.cs" />
     <Compile Include="Form1.cs">
       <SubType>Form</SubType>
     </Compile>

--- a/Inventory Management App/sample.cs
+++ b/Inventory Management App/sample.cs
@@ -1,0 +1,106 @@
+private void UpdateButton_Click(object sender, EventArgs e)
+{
+    // ========================================
+    // ステップ1: ユーザーに保存確認
+    // ========================================
+    DialogResult result = MessageBox.Show(
+        "DataGridViewの全データをデータベースに保存しますか？",
+        "保存確認",
+        MessageBoxButtons.YesNo,
+        MessageBoxIcon.Question
+    );
+
+    // 「いいえ」が選択された場合、処理を中断
+    if (result != DialogResult.Yes) return;
+
+    try
+    {
+
+        int insertedCount = 0;  // 新規挿入されたレコード数
+        int updatedCount = 0;   // 更新されたレコード数
+
+        using (SqliteConnection connection = new SqliteConnection(connectionString))
+        {
+            // データベースへの接続を開始
+            connection.Open();
+
+            using (SqliteTransaction transaction = connection.BeginTransaction())
+            {
+
+                    string updateQuery = @"
+                        UPDATE InventoryItems
+                        SET IsChecked = @IsChecked,
+                            Time = @Time,
+                            Quantity = @Quantity,
+                            Comment = @Comment
+                        WHERE Id = @Id";
+
+                    string insertQuery = @"
+                        INSERT INTO InventoryItems (IsChecked, Time, Quantity, Comment)
+                        VALUES (@IsChecked, @Time, @Quantity, @Comment)";
+
+                    foreach (DataGridViewRow row in inventoryDataGridView.Rows)
+                    {
+
+                        bool isChecked = row.Cells[COLUMN_INDEX_CHECKBOX].Value is bool checkValue && checkValue;
+
+                        string time = row.Cells[COLUMN_INDEX_TIME].Value?.ToString() 
+                                     ?? DateTime.Now.ToString("HH:mm:ss");
+
+
+                        string quantityText = row.Cells[COLUMN_INDEX_QUANTITY].Value?.ToString()?.Replace(",", "") 
+                                            ?? "0";
+
+                        int quantity = int.TryParse(quantityText, out int qty) ? qty : 0;
+                        
+                        string comment = row.Cells[COLUMN_INDEX_COMMENT].Value?.ToString() ?? "";
+
+
+                        if (row.Tag != null && row.Tag is int id)
+                        {
+
+                            using (SqliteCommand updateCommand = new SqliteCommand(updateQuery, connection, transaction))
+                            {
+                                updateCommand.Parameters.AddWithValue("@Id", id);
+                                updateCommand.Parameters.AddWithValue("@IsChecked", isChecked ? 1 : 0);
+                                updateCommand.Parameters.AddWithValue("@Time", time);
+                                updateCommand.Parameters.AddWithValue("@Quantity", quantity);
+                                updateCommand.Parameters.AddWithValue("@Comment", comment);
+
+                                updateCommand.ExecuteNonQuery();
+
+                                updatedCount++;
+                            }
+
+                        }
+                        else
+                        {
+
+                            using (SqliteCommand insertCommand = new SqliteCommand(insertQuery, connection, transaction))
+                            {
+                                insertCommand.Parameters.AddWithValue("@IsChecked", isChecked ? 1 : 0);
+                                insertCommand.Parameters.AddWithValue("@Time", time);
+                                insertCommand.Parameters.AddWithValue("@Quantity", quantity);
+                                insertCommand.Parameters.AddWithValue("@Comment", comment);
+
+                                insertCommand.ExecuteNonQuery();
+                                insertedCount++;
+                            }
+                        }
+                    }
+
+
+                    transaction.Commit();
+                }
+            }
+
+        LoadDataFromDatabase();
+
+        MessageBox.Show(
+            $"保存完了\n新規: {insertedCount}件\n更新: {updatedCount}件",
+            "保存完了",
+            MessageBoxButtons.OK,
+            MessageBoxIcon.Information
+        );
+    }
+}


### PR DESCRIPTION
## やったこと
①詳細ボタンの実装。
②詳細ボタン押下が別画面の作成。
③別画面での画像の挿入と削除ボタンの実装。


## 実装途中
①画像を挿入した際に画像が見切れる。（画像のリサイズなどの機能が必要）
②画像の保存（サーバー上の保存）　※画像の保存のボタンは実装済み。クリックイベントは未実装。
③変数名などの再定義。

## アプリ（メイン画面）
<img width="1045" height="702" alt="image" src="https://github.com/user-attachments/assets/a292e0a6-10b3-4e41-b225-7866f664c680" />

## アプリ（サブ画面）
アプリ（メイン画面）の詳細ボタン押下時にサブ画面が表示
<img width="1706" height="898" alt="image" src="https://github.com/user-attachments/assets/1259c13f-74df-490a-885c-a3071c36441f" />

## 画像挿入後のアプリ（サブ画面）
画像が見切れている。
<img width="1172" height="495" alt="image" src="https://github.com/user-attachments/assets/81499d91-4066-4860-a46f-f783b67a02a5" />

画像挿入した元画像
<img width="1024" height="1536" alt="ChatGPT Image 2025年4月24日 09_12_56" src="https://github.com/user-attachments/assets/868ee578-7db3-48b4-847c-f122dff972bf" />

